### PR TITLE
feat: implement #23. Manage internal and external certificate on same way

### DIFF
--- a/controllers/kibana/builder_deployment.go
+++ b/controllers/kibana/builder_deployment.go
@@ -43,7 +43,7 @@ func BuildDeployment(kb *kibanacrd.Kibana, es *elasticsearchcrd.Elasticsearch, k
 
 	secretChecksumAnnotations := map[string]string{}
 	// Compute checksum annotation for keystore secrets
-	if kb.Spec.KeystoreSecretRef != nil && kb.Spec.KeystoreSecretRef.Name != "" && keystoreSecret != nil {
+	if keystoreSecret != nil {
 		//Convert secret contend to json string and them checksum it
 		j, err := json.Marshal(keystoreSecret.Data)
 		if err != nil {
@@ -55,8 +55,8 @@ func BuildDeployment(kb *kibanacrd.Kibana, es *elasticsearchcrd.Elasticsearch, k
 		}
 		secretChecksumAnnotations[fmt.Sprintf("%s/checksum-keystore", KibanaAnnotationKey)] = sum
 	}
-	// Compute checksum annotation for external API certs
-	if kb.IsTlsEnabled() && !kb.IsSelfManagedSecretForTls() && apiCrtSecret != nil {
+	// Compute checksum annotation for API certs
+	if apiCrtSecret != nil {
 		//Convert secret contend to json string and them checksum it
 		j, err := json.Marshal(apiCrtSecret.Data)
 		if err != nil {
@@ -68,8 +68,8 @@ func BuildDeployment(kb *kibanacrd.Kibana, es *elasticsearchcrd.Elasticsearch, k
 		}
 		secretChecksumAnnotations[fmt.Sprintf("%s/checksum-api-certs", KibanaAnnotationKey)] = sum
 	}
-	// Compute checksum annotation for external CA Elasticsearch secret
-	if !kb.Spec.ElasticsearchRef.IsManaged() && kb.Spec.Tls.ElasticsearchCaSecretRef != nil && esCASecret != nil {
+	// Compute checksum annotation for CA Elasticsearch secret
+	if esCASecret != nil {
 		//Convert secret contend to json string and them checksum it
 		j, err := json.Marshal(esCASecret.Data)
 		if err != nil {

--- a/controllers/kibana/controller_secret_tls.go
+++ b/controllers/kibana/controller_secret_tls.go
@@ -1,13 +1,10 @@
 package kibana
 
 import (
-	"bytes"
 	"context"
 	"crypto/x509"
-	"fmt"
 	"time"
 
-	"github.com/codingsince1985/checksum"
 	"github.com/disaster37/goca"
 	"github.com/disaster37/goca/cert"
 	"github.com/disaster37/k8s-objectmatcher/patch"
@@ -19,16 +16,13 @@ import (
 	"github.com/webcenter-fr/elasticsearch-operator/controllers/common"
 	localhelper "github.com/webcenter-fr/elasticsearch-operator/pkg/helper"
 	"github.com/webcenter-fr/elasticsearch-operator/pkg/pki"
-	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	condition "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	podutil "k8s.io/kubectl/pkg/util/podutils"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -36,18 +30,9 @@ import (
 type tlsPhase string
 
 const (
-	TlsConditionGenerateCertificate  = "TlsGenerateCertificates"
-	TlsConditionPropagateCertificate = "TlsPropagateCertificates"
-	TlsCondition                     = "TlsReady"
-	TlsPhase                         = "Tls"
-	DefaultRenewCertificate          = -time.Hour * 24 * 30 // 30 days before expired
-)
-
-var (
-	phaseTlsCreate                tlsPhase = "tlsCreate"
-	phaseTlsUpdateCertificates    tlsPhase = "tlsUpdateCertificates"
-	phaseTlsPropagateCertificates tlsPhase = "tlsPropagateCertificates"
-	phaseTlsNormal                tlsPhase = "tlsNormal"
+	TlsCondition            = "TlsReady"
+	TlsPhase                = "Tls"
+	DefaultRenewCertificate = -time.Hour * 24 * 30 // 30 days before expired
 )
 
 type TlsReconciler struct {
@@ -81,22 +66,6 @@ func (r *TlsReconciler) Configure(ctx context.Context, req ctrl.Request, resourc
 		})
 
 		o.Status.Phase = TlsPhase
-	}
-
-	if condition.FindStatusCondition(o.Status.Conditions, TlsConditionGenerateCertificate) == nil {
-		condition.SetStatusCondition(&o.Status.Conditions, metav1.Condition{
-			Type:   TlsConditionGenerateCertificate,
-			Status: metav1.ConditionFalse,
-			Reason: "Initialize",
-		})
-	}
-
-	if condition.FindStatusCondition(o.Status.Conditions, TlsConditionPropagateCertificate) == nil {
-		condition.SetStatusCondition(&o.Status.Conditions, metav1.Condition{
-			Type:   TlsConditionPropagateCertificate,
-			Status: metav1.ConditionFalse,
-			Reason: "Initialize",
-		})
 	}
 
 	return res, nil
@@ -205,10 +174,9 @@ func (r *TlsReconciler) Diff(ctx context.Context, resource client.Object, data m
 	secretToCreate := make([]client.Object, 0)
 	secretToDelete := make([]client.Object, 0)
 
-	// phaseInit -> phaseCreate
 	// Generate all certificates
 	if sApi == nil || sApiPki == nil {
-		r.Log.Debugf("Detect phase: %s", phaseTlsCreate)
+		r.Log.Debugf("Generate all certificates")
 
 		diff.Diff.WriteString("Generate new certificates\n")
 
@@ -267,17 +235,7 @@ func (r *TlsReconciler) Diff(ctx context.Context, resource client.Object, data m
 		data["listToCreate"] = secretToCreate
 		data["listToUpdate"] = secretToUpdate
 		data["listToDelete"] = secretToDelete
-		data["phase"] = phaseTlsCreate
 
-		return diff, res, nil
-	}
-
-	// phaseGenerateCertificate -> phasePropagateCertificate
-	// Wait new certificates propagated on all Elasticsearch instance
-	if condition.IsStatusConditionPresentAndEqual(o.Status.Conditions, TlsConditionGenerateCertificate, metav1.ConditionTrue) && condition.IsStatusConditionPresentAndEqual(o.Status.Conditions, TlsConditionPropagateCertificate, metav1.ConditionFalse) {
-		r.Log.Debugf("Detect phase: %s", phaseTlsPropagateCertificates)
-
-		data["phase"] = phaseTlsPropagateCertificates
 		return diff, res, nil
 	}
 
@@ -312,7 +270,7 @@ func (r *TlsReconciler) Diff(ctx context.Context, resource client.Object, data m
 	}
 
 	if isRenew {
-		r.Log.Debugf("Detect phase: %s", phaseTlsUpdateCertificates)
+		r.Log.Debugf("Renew all certificates")
 
 		if o.IsTlsEnabled() && o.IsSelfManagedSecretForTls() {
 			tmpApiPki, apiRootCA, err := BuildPkiSecret(o)
@@ -367,7 +325,6 @@ func (r *TlsReconciler) Diff(ctx context.Context, resource client.Object, data m
 		data["listToCreate"] = secretToCreate
 		data["listToUpdate"] = secretToUpdate
 		data["listToDelete"] = secretToDelete
-		data["phase"] = phaseTlsUpdateCertificates
 
 		return diff, res, nil
 	}
@@ -411,7 +368,6 @@ func (r *TlsReconciler) Diff(ctx context.Context, resource client.Object, data m
 	data["listToCreate"] = secretToCreate
 	data["listToUpdate"] = secretToUpdate
 	data["listToDelete"] = secretToDelete
-	data["phase"] = phaseTlsNormal
 
 	return diff, res, nil
 }
@@ -438,157 +394,19 @@ func (r *TlsReconciler) OnError(ctx context.Context, resource client.Object, dat
 // OnSuccess permit to set status condition on the right state is everithink is good
 func (r *TlsReconciler) OnSuccess(ctx context.Context, resource client.Object, data map[string]any, diff controller.K8sDiff) (res ctrl.Result, err error) {
 	o := resource.(*kibanacrd.Kibana)
-	var (
-		d any
-	)
 
-	d, err = helper.Get(data, "phase")
-	if err != nil {
-		return res, err
+	if diff.NeedCreate || diff.NeedUpdate || diff.NeedDelete {
+		r.Recorder.Eventf(resource, corev1.EventTypeNormal, "Completed", "TLS certificates successfully updated")
 	}
-	phase := d.(tlsPhase)
 
-	d, err = helper.Get(data, "apiTlsSecret")
-	if err != nil {
-		return res, err
-	}
-	sApi := d.(*corev1.Secret)
-
-	switch phase {
-	case phaseTlsCreate:
-		r.Recorder.Eventf(resource, corev1.EventTypeNormal, "Completed", "Tls secrets successfully generated")
-
+	// Update condition status if needed
+	if !condition.IsStatusConditionPresentAndEqual(o.Status.Conditions, TlsCondition, metav1.ConditionTrue) {
 		condition.SetStatusCondition(&o.Status.Conditions, metav1.Condition{
 			Type:    TlsCondition,
 			Reason:  "Success",
 			Status:  metav1.ConditionTrue,
 			Message: "Ready",
 		})
-
-		condition.SetStatusCondition(&o.Status.Conditions, metav1.Condition{
-			Type:    TlsConditionGenerateCertificate,
-			Reason:  "Success",
-			Status:  metav1.ConditionTrue,
-			Message: "Certificates generated",
-		})
-
-		condition.SetStatusCondition(&o.Status.Conditions, metav1.Condition{
-			Type:    TlsConditionPropagateCertificate,
-			Reason:  "Success",
-			Status:  metav1.ConditionTrue,
-			Message: "Certificates propagated",
-		})
-
-		r.Log.Info("Phase Create all certificates successfully finished")
-
-	case phaseTlsUpdateCertificates:
-		condition.SetStatusCondition(&o.Status.Conditions, metav1.Condition{
-			Type:    TlsCondition,
-			Reason:  "NotReady",
-			Status:  metav1.ConditionFalse,
-			Message: "Generete new certificates",
-		})
-
-		condition.SetStatusCondition(&o.Status.Conditions, metav1.Condition{
-			Type:    TlsConditionGenerateCertificate,
-			Reason:  "Success",
-			Status:  metav1.ConditionTrue,
-			Message: "Certificates generated",
-		})
-
-		condition.SetStatusCondition(&o.Status.Conditions, metav1.Condition{
-			Type:    TlsConditionPropagateCertificate,
-			Reason:  "NotPropaged",
-			Status:  metav1.ConditionFalse,
-			Message: "Not yet propaged",
-		})
-
-		r.Log.Info("Phase propagate certificates: all certificates have been successfully renewed")
-		return ctrl.Result{Requeue: true}, nil
-
-	case phaseTlsPropagateCertificates:
-		// Get deployment to check the new certificates to be propagated
-		// And deployment finished rolling upgrade
-
-		dpl := &appv1.Deployment{}
-		podList := &corev1.PodList{}
-		annotation := fmt.Sprintf("%s/ca-checksum", KibanaAnnotationKey)
-		caChecksum, err := checksum.SHA256sumReader(bytes.NewReader(sApi.Data["ca.crt"]))
-		if err != nil {
-			return res, errors.Wrap(err, "Error when generate checksum from ca.crt")
-		}
-		if err = r.Client.Get(ctx, types.NamespacedName{Namespace: o.Namespace, Name: o.Name}, dpl); err != nil {
-			if k8serrors.IsNotFound(err) {
-				condition.SetStatusCondition(&o.Status.Conditions, metav1.Condition{
-					Type:    TlsConditionPropagateCertificate,
-					Reason:  "Ready",
-					Status:  metav1.ConditionTrue,
-					Message: "Certificates propaged",
-				})
-				condition.SetStatusCondition(&o.Status.Conditions, metav1.Condition{
-					Type:    TlsCondition,
-					Reason:  "Ready",
-					Status:  metav1.ConditionTrue,
-					Message: "Generete new certificates",
-				})
-
-				r.Log.Info("Phase propagate certificates: all certificates have been successfully renewed")
-				return ctrl.Result{Requeue: true}, nil
-			}
-			return res, errors.Wrapf(err, "Error when read Elasticsearch statefullsets")
-		}
-
-		// First, check if deployment currently upgraded
-		if dpl.Spec.Template.Annotations[annotation] != "" && dpl.Spec.Template.Annotations[annotation] == caChecksum {
-			labelSelectors := labels.SelectorFromSet(dpl.Spec.Template.Labels)
-			if err = r.Client.List(ctx, podList, &client.ListOptions{Namespace: o.Namespace, LabelSelector: labelSelectors}); err != nil {
-				return res, errors.Wrapf(err, "Error when read Kibana pods")
-			}
-
-			isFinished := true
-			for _, p := range podList.Items {
-				// The pod must have CA checksum annotation and need to be ready
-				if p.Annotations[annotation] == "" || p.Annotations[annotation] != caChecksum || !podutil.IsPodReady(&p) {
-					isFinished = false
-				}
-			}
-			if !isFinished {
-				// All Sts not yet finished upgrade
-				r.Log.Info("Phase propagate certificates: wait pod to be ready")
-				return ctrl.Result{RequeueAfter: time.Second * 30}, nil
-			}
-		}
-
-		// Then, check if deployment receive the new certificates
-		// Check CA is updated
-		if dpl.Spec.Template.Annotations[annotation] == "" || dpl.Spec.Template.Annotations[annotation] != caChecksum {
-			dpl.Spec.Template.Annotations[annotation] = caChecksum
-			if err = r.Client.Update(ctx, dpl); err != nil {
-				return res, errors.Wrapf(err, "Error when update deployment %s", dpl.Name)
-			}
-
-			condition.SetStatusCondition(&o.Status.Conditions, metav1.Condition{
-				Type:    TlsConditionPropagateCertificate,
-				Reason:  "Propagate",
-				Status:  metav1.ConditionFalse,
-				Message: "Propagate certificate",
-			})
-
-			r.Log.Infof("Phase propagate certificates: wait deployment %s restart with new certificates", dpl.Name)
-			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
-		}
-
-		// all certificate upgrade are finished
-		condition.SetStatusCondition(&o.Status.Conditions, metav1.Condition{
-			Type:    TlsConditionPropagateCertificate,
-			Reason:  "Success",
-			Status:  metav1.ConditionTrue,
-			Message: "Certificates propagated",
-		})
-
-		r.Log.Info("Phase propagate certificates: all nodes have beed successfully restarted with new certificates")
-
-		return ctrl.Result{Requeue: true}, nil
 	}
 
 	return res, nil


### PR DESCRIPTION
Reconcile deployment on same way when internal or external certificate is updated (API certificate and CA certificate of Elasticsearch)

Signed-off-by: disaster37 <linuxworkgroup@hotmail.com>