### PR TITLE
fix: fix how to renew certificates on Elasticsearch. 

### DIFF
--- a/apis/beat/v1alpha1/filebeat_func.go
+++ b/apis/beat/v1alpha1/filebeat_func.go
@@ -125,13 +125,13 @@ func MustSetUpIndexForFilebeat(k8sManager manager.Manager) {
 		panic(err)
 	}
 
-	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Filebeat{}, "spec.deployment.additionalVolumes.name", func(o client.Object) []string {
+	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Filebeat{}, "spec.deployment.additionalVolumes.configMap.name", func(o client.Object) []string {
 		p := o.(*Filebeat)
 		volumeNames := make([]string, 0, len(p.Spec.Deployment.AdditionalVolumes))
 
 		for _, volume := range p.Spec.Deployment.AdditionalVolumes {
-			if volume.ConfigMap != nil || volume.Secret != nil {
-				volumeNames = append(volumeNames, volume.Name)
+			if volume.ConfigMap != nil {
+				volumeNames = append(volumeNames, volume.ConfigMap.Name)
 			}
 		}
 
@@ -140,13 +140,28 @@ func MustSetUpIndexForFilebeat(k8sManager manager.Manager) {
 		panic(err)
 	}
 
-	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Filebeat{}, "spec.deployment.env.name", func(o client.Object) []string {
+	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Filebeat{}, "spec.deployment.additionalVolumes.secret.secretName", func(o client.Object) []string {
+		p := o.(*Filebeat)
+		volumeNames := make([]string, 0, len(p.Spec.Deployment.AdditionalVolumes))
+
+		for _, volume := range p.Spec.Deployment.AdditionalVolumes {
+			if volume.Secret != nil {
+				volumeNames = append(volumeNames, volume.Secret.SecretName)
+			}
+		}
+
+		return volumeNames
+	}); err != nil {
+		panic(err)
+	}
+
+	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Filebeat{}, "spec.deployment.env.valueFrom.configMapKeyRef.name", func(o client.Object) []string {
 		p := o.(*Filebeat)
 		envNames := make([]string, 0, len(p.Spec.Deployment.Env))
 
 		for _, env := range p.Spec.Deployment.Env {
-			if env.ValueFrom != nil && (env.ValueFrom.SecretKeyRef != nil || env.ValueFrom.ConfigMapKeyRef != nil) {
-				envNames = append(envNames, env.Name)
+			if env.ValueFrom != nil && env.ValueFrom.ConfigMapKeyRef != nil {
+				envNames = append(envNames, env.ValueFrom.ConfigMapKeyRef.Name)
 			}
 		}
 
@@ -155,14 +170,42 @@ func MustSetUpIndexForFilebeat(k8sManager manager.Manager) {
 		panic(err)
 	}
 
-	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Filebeat{}, "spec.deployment.envFrom.name", func(o client.Object) []string {
+	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Filebeat{}, "spec.deployment.env.valueFrom.secretKeyRef.name", func(o client.Object) []string {
+		p := o.(*Filebeat)
+		envNames := make([]string, 0, len(p.Spec.Deployment.Env))
+
+		for _, env := range p.Spec.Deployment.Env {
+			if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
+				envNames = append(envNames, env.ValueFrom.SecretKeyRef.Name)
+			}
+		}
+
+		return envNames
+	}); err != nil {
+		panic(err)
+	}
+
+	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Filebeat{}, "spec.deployment.envFrom.configMapRef.name", func(o client.Object) []string {
 		p := o.(*Filebeat)
 		envFromNames := make([]string, 0, len(p.Spec.Deployment.EnvFrom))
 
 		for _, envFrom := range p.Spec.Deployment.EnvFrom {
 			if envFrom.ConfigMapRef != nil {
 				envFromNames = append(envFromNames, envFrom.ConfigMapRef.Name)
-			} else if envFrom.SecretRef != nil {
+			}
+		}
+
+		return envFromNames
+	}); err != nil {
+		panic(err)
+	}
+
+	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Filebeat{}, "spec.deployment.envFrom.secretRef.name", func(o client.Object) []string {
+		p := o.(*Filebeat)
+		envFromNames := make([]string, 0, len(p.Spec.Deployment.EnvFrom))
+
+		for _, envFrom := range p.Spec.Deployment.EnvFrom {
+			if envFrom.SecretRef != nil {
 				envFromNames = append(envFromNames, envFrom.SecretRef.Name)
 			}
 		}

--- a/apis/beat/v1alpha1/metricbeat_func.go
+++ b/apis/beat/v1alpha1/metricbeat_func.go
@@ -62,13 +62,13 @@ func MustSetUpIndexForMetricbeat(k8sManager manager.Manager) {
 		panic(err)
 	}
 
-	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Metricbeat{}, "spec.deployment.additionalVolumes.name", func(o client.Object) []string {
+	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Metricbeat{}, "spec.deployment.additionalVolumes.configMap.name", func(o client.Object) []string {
 		p := o.(*Metricbeat)
 		volumeNames := make([]string, 0, len(p.Spec.Deployment.AdditionalVolumes))
 
 		for _, volume := range p.Spec.Deployment.AdditionalVolumes {
-			if volume.ConfigMap != nil || volume.Secret != nil {
-				volumeNames = append(volumeNames, volume.Name)
+			if volume.ConfigMap != nil {
+				volumeNames = append(volumeNames, volume.ConfigMap.Name)
 			}
 		}
 
@@ -77,13 +77,28 @@ func MustSetUpIndexForMetricbeat(k8sManager manager.Manager) {
 		panic(err)
 	}
 
-	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Metricbeat{}, "spec.deployment.env.name", func(o client.Object) []string {
+	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Metricbeat{}, "spec.deployment.additionalVolumes.secret.secretName", func(o client.Object) []string {
+		p := o.(*Metricbeat)
+		volumeNames := make([]string, 0, len(p.Spec.Deployment.AdditionalVolumes))
+
+		for _, volume := range p.Spec.Deployment.AdditionalVolumes {
+			if volume.Secret != nil {
+				volumeNames = append(volumeNames, volume.Secret.SecretName)
+			}
+		}
+
+		return volumeNames
+	}); err != nil {
+		panic(err)
+	}
+
+	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Metricbeat{}, "spec.deployment.env.valueFrom.configMapKeyRef.name", func(o client.Object) []string {
 		p := o.(*Metricbeat)
 		envNames := make([]string, 0, len(p.Spec.Deployment.Env))
 
 		for _, env := range p.Spec.Deployment.Env {
-			if env.ValueFrom != nil && (env.ValueFrom.SecretKeyRef != nil || env.ValueFrom.ConfigMapKeyRef != nil) {
-				envNames = append(envNames, env.Name)
+			if env.ValueFrom != nil && env.ValueFrom.ConfigMapKeyRef != nil {
+				envNames = append(envNames, env.ValueFrom.ConfigMapKeyRef.Name)
 			}
 		}
 
@@ -92,14 +107,42 @@ func MustSetUpIndexForMetricbeat(k8sManager manager.Manager) {
 		panic(err)
 	}
 
-	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Metricbeat{}, "spec.deployment.envFrom.name", func(o client.Object) []string {
+	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Metricbeat{}, "spec.deployment.env.valueFrom.secretKeyRef.name", func(o client.Object) []string {
+		p := o.(*Metricbeat)
+		envNames := make([]string, 0, len(p.Spec.Deployment.Env))
+
+		for _, env := range p.Spec.Deployment.Env {
+			if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
+				envNames = append(envNames, env.ValueFrom.SecretKeyRef.Name)
+			}
+		}
+
+		return envNames
+	}); err != nil {
+		panic(err)
+	}
+
+	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Metricbeat{}, "spec.deployment.envFrom.configMapRef.name", func(o client.Object) []string {
 		p := o.(*Metricbeat)
 		envFromNames := make([]string, 0, len(p.Spec.Deployment.EnvFrom))
 
 		for _, envFrom := range p.Spec.Deployment.EnvFrom {
 			if envFrom.ConfigMapRef != nil {
 				envFromNames = append(envFromNames, envFrom.ConfigMapRef.Name)
-			} else if envFrom.SecretRef != nil {
+			}
+		}
+
+		return envFromNames
+	}); err != nil {
+		panic(err)
+	}
+
+	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Metricbeat{}, "spec.deployment.envFrom.secretRef.name", func(o client.Object) []string {
+		p := o.(*Metricbeat)
+		envFromNames := make([]string, 0, len(p.Spec.Deployment.EnvFrom))
+
+		for _, envFrom := range p.Spec.Deployment.EnvFrom {
+			if envFrom.SecretRef != nil {
 				envFromNames = append(envFromNames, envFrom.SecretRef.Name)
 			}
 		}

--- a/apis/kibana/v1alpha1/kibana_func.go
+++ b/apis/kibana/v1alpha1/kibana_func.go
@@ -125,13 +125,13 @@ func MustSetUpIndex(k8sManager manager.Manager) {
 		panic(err)
 	}
 
-	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Kibana{}, "spec.deployment.env.name", func(o client.Object) []string {
+	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Kibana{}, "spec.deployment.env.valueFrom.configMapKeyRef.name", func(o client.Object) []string {
 		p := o.(*Kibana)
 		envNames := make([]string, 0, len(p.Spec.Deployment.Env))
 
 		for _, env := range p.Spec.Deployment.Env {
-			if env.ValueFrom != nil && (env.ValueFrom.SecretKeyRef != nil || env.ValueFrom.ConfigMapKeyRef != nil) {
-				envNames = append(envNames, env.Name)
+			if env.ValueFrom != nil && env.ValueFrom.ConfigMapKeyRef != nil {
+				envNames = append(envNames, env.ValueFrom.ConfigMapKeyRef.Name)
 			}
 		}
 
@@ -140,14 +140,42 @@ func MustSetUpIndex(k8sManager manager.Manager) {
 		panic(err)
 	}
 
-	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Kibana{}, "spec.deployment.envFrom.name", func(o client.Object) []string {
+	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Kibana{}, "spec.deployment.env.valueFrom.secretKeyRef.name", func(o client.Object) []string {
+		p := o.(*Kibana)
+		envNames := make([]string, 0, len(p.Spec.Deployment.Env))
+
+		for _, env := range p.Spec.Deployment.Env {
+			if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
+				envNames = append(envNames, env.ValueFrom.SecretKeyRef.Name)
+			}
+		}
+
+		return envNames
+	}); err != nil {
+		panic(err)
+	}
+
+	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Kibana{}, "spec.deployment.envFrom.configMapRef.name", func(o client.Object) []string {
 		p := o.(*Kibana)
 		envFromNames := make([]string, 0, len(p.Spec.Deployment.EnvFrom))
 
 		for _, envFrom := range p.Spec.Deployment.EnvFrom {
 			if envFrom.ConfigMapRef != nil {
 				envFromNames = append(envFromNames, envFrom.ConfigMapRef.Name)
-			} else if envFrom.SecretRef != nil {
+			}
+		}
+
+		return envFromNames
+	}); err != nil {
+		panic(err)
+	}
+
+	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Kibana{}, "spec.deployment.envFrom.secretRef.name", func(o client.Object) []string {
+		p := o.(*Kibana)
+		envFromNames := make([]string, 0, len(p.Spec.Deployment.EnvFrom))
+
+		for _, envFrom := range p.Spec.Deployment.EnvFrom {
+			if envFrom.SecretRef != nil {
 				envFromNames = append(envFromNames, envFrom.SecretRef.Name)
 			}
 		}

--- a/apis/logstash/v1alpha1/logstash_func.go
+++ b/apis/logstash/v1alpha1/logstash_func.go
@@ -93,13 +93,13 @@ func MustSetUpIndex(k8sManager manager.Manager) {
 		panic(err)
 	}
 
-	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Logstash{}, "spec.deployment.additionalVolumes.name", func(o client.Object) []string {
+	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Logstash{}, "spec.deployment.additionalVolumes.configMap.name", func(o client.Object) []string {
 		p := o.(*Logstash)
 		volumeNames := make([]string, 0, len(p.Spec.Deployment.AdditionalVolumes))
 
 		for _, volume := range p.Spec.Deployment.AdditionalVolumes {
-			if volume.ConfigMap != nil || volume.Secret != nil {
-				volumeNames = append(volumeNames, volume.Name)
+			if volume.ConfigMap != nil {
+				volumeNames = append(volumeNames, volume.ConfigMap.Name)
 			}
 		}
 
@@ -108,13 +108,28 @@ func MustSetUpIndex(k8sManager manager.Manager) {
 		panic(err)
 	}
 
-	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Logstash{}, "spec.deployment.env.name", func(o client.Object) []string {
+	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Logstash{}, "spec.deployment.additionalVolumes.secret.secretName", func(o client.Object) []string {
+		p := o.(*Logstash)
+		volumeNames := make([]string, 0, len(p.Spec.Deployment.AdditionalVolumes))
+
+		for _, volume := range p.Spec.Deployment.AdditionalVolumes {
+			if volume.Secret != nil {
+				volumeNames = append(volumeNames, volume.Secret.SecretName)
+			}
+		}
+
+		return volumeNames
+	}); err != nil {
+		panic(err)
+	}
+
+	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Logstash{}, "spec.deployment.env.valueFrom.configMapKeyRef.name", func(o client.Object) []string {
 		p := o.(*Logstash)
 		envNames := make([]string, 0, len(p.Spec.Deployment.Env))
 
 		for _, env := range p.Spec.Deployment.Env {
-			if env.ValueFrom != nil && (env.ValueFrom.SecretKeyRef != nil || env.ValueFrom.ConfigMapKeyRef != nil) {
-				envNames = append(envNames, env.Name)
+			if env.ValueFrom != nil && env.ValueFrom.ConfigMapKeyRef != nil {
+				envNames = append(envNames, env.ValueFrom.ConfigMapKeyRef.Name)
 			}
 		}
 
@@ -123,14 +138,42 @@ func MustSetUpIndex(k8sManager manager.Manager) {
 		panic(err)
 	}
 
-	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Logstash{}, "spec.deployment.envFrom.name", func(o client.Object) []string {
+	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Logstash{}, "spec.deployment.env.valueFrom.secretKeyRef.name", func(o client.Object) []string {
+		p := o.(*Logstash)
+		envNames := make([]string, 0, len(p.Spec.Deployment.Env))
+
+		for _, env := range p.Spec.Deployment.Env {
+			if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
+				envNames = append(envNames, env.ValueFrom.SecretKeyRef.Name)
+			}
+		}
+
+		return envNames
+	}); err != nil {
+		panic(err)
+	}
+
+	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Logstash{}, "spec.deployment.envFrom.configMapRef.name", func(o client.Object) []string {
 		p := o.(*Logstash)
 		envFromNames := make([]string, 0, len(p.Spec.Deployment.EnvFrom))
 
 		for _, envFrom := range p.Spec.Deployment.EnvFrom {
 			if envFrom.ConfigMapRef != nil {
 				envFromNames = append(envFromNames, envFrom.ConfigMapRef.Name)
-			} else if envFrom.SecretRef != nil {
+			}
+		}
+
+		return envFromNames
+	}); err != nil {
+		panic(err)
+	}
+
+	if err := k8sManager.GetFieldIndexer().IndexField(context.Background(), &Logstash{}, "spec.deployment.envFrom.secretRef.name", func(o client.Object) []string {
+		p := o.(*Logstash)
+		envFromNames := make([]string, 0, len(p.Spec.Deployment.EnvFrom))
+
+		for _, envFrom := range p.Spec.Deployment.EnvFrom {
+			if envFrom.SecretRef != nil {
 				envFromNames = append(envFromNames, envFrom.SecretRef.Name)
 			}
 		}

--- a/controllers/elasticsearch/elasticsearch_controller.go
+++ b/controllers/elasticsearch/elasticsearch_controller.go
@@ -208,7 +208,7 @@ func watchConfigMap(c client.Client) handler.MapFunc {
 
 		// Additional volumes configMap
 		listElasticsearch = &elasticsearchcrd.ElasticsearchList{}
-		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.globalNodeGroup.additionalVolumes.name=%s", a.GetName()))
+		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.globalNodeGroup.additionalVolumes.configMap.name=%s", a.GetName()))
 		// Get all elasticsearch linked with secret
 		if err := c.List(context.Background(), listElasticsearch, &client.ListOptions{Namespace: a.GetNamespace(), FieldSelector: fs}); err != nil {
 			panic(err)
@@ -219,7 +219,7 @@ func watchConfigMap(c client.Client) handler.MapFunc {
 
 		// Env of type configMap
 		listElasticsearch = &elasticsearchcrd.ElasticsearchList{}
-		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.statefulset.env.name=%s", a.GetName()))
+		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.statefulset.env.valueFrom.configMapKeyRef.name=%s", a.GetName()))
 		// Get all elasticsearch linked with secret
 		if err := c.List(context.Background(), listElasticsearch, &client.ListOptions{Namespace: a.GetNamespace(), FieldSelector: fs}); err != nil {
 			panic(err)
@@ -230,7 +230,7 @@ func watchConfigMap(c client.Client) handler.MapFunc {
 
 		// EnvFrom of type configMap
 		listElasticsearch = &elasticsearchcrd.ElasticsearchList{}
-		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.statefulset.envFrom.name=%s", a.GetName()))
+		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.statefulset.envFrom.configMapRef.name=%s", a.GetName()))
 		// Get all elasticsearch linked with secret
 		if err := c.List(context.Background(), listElasticsearch, &client.ListOptions{Namespace: a.GetNamespace(), FieldSelector: fs}); err != nil {
 			panic(err)
@@ -289,7 +289,7 @@ func watchSecret(c client.Client) handler.MapFunc {
 
 		// Additional volumes secrets
 		listElasticsearch = &elasticsearchcrd.ElasticsearchList{}
-		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.globalNodeGroup.additionalVolumes.name=%s", a.GetName()))
+		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.globalNodeGroup.additionalVolumes.secret.secretName=%s", a.GetName()))
 		// Get all elasticsearch linked with secret
 		if err := c.List(context.Background(), listElasticsearch, &client.ListOptions{Namespace: a.GetNamespace(), FieldSelector: fs}); err != nil {
 			panic(err)
@@ -300,7 +300,7 @@ func watchSecret(c client.Client) handler.MapFunc {
 
 		// Env of type secrets
 		listElasticsearch = &elasticsearchcrd.ElasticsearchList{}
-		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.statefulset.env.name=%s", a.GetName()))
+		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.statefulset.env.valueFrom.secretKeyRef.name=%s", a.GetName()))
 		// Get all elasticsearch linked with secret
 		if err := c.List(context.Background(), listElasticsearch, &client.ListOptions{Namespace: a.GetNamespace(), FieldSelector: fs}); err != nil {
 			panic(err)
@@ -311,7 +311,7 @@ func watchSecret(c client.Client) handler.MapFunc {
 
 		// EnvFrom of type secrets
 		listElasticsearch = &elasticsearchcrd.ElasticsearchList{}
-		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.statefulset.envFrom.name=%s", a.GetName()))
+		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.statefulset.envFrom.secretRef.name=%s", a.GetName()))
 		// Get all elasticsearch linked with secret
 		if err := c.List(context.Background(), listElasticsearch, &client.ListOptions{Namespace: a.GetNamespace(), FieldSelector: fs}); err != nil {
 			panic(err)

--- a/controllers/filebeat/filebeat_controller.go
+++ b/controllers/filebeat/filebeat_controller.go
@@ -205,7 +205,7 @@ func watchConfigMap(c client.Client) handler.MapFunc {
 
 		// Additional volumes secrets
 		listFilebeats = &beatcrd.FilebeatList{}
-		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.additionalVolumes.name=%s", a.GetName()))
+		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.additionalVolumes.configMap.name=%s", a.GetName()))
 		if err := c.List(context.Background(), listFilebeats, &client.ListOptions{Namespace: a.GetNamespace(), FieldSelector: fs}); err != nil {
 			panic(err)
 		}
@@ -215,7 +215,7 @@ func watchConfigMap(c client.Client) handler.MapFunc {
 
 		// Env of type secrets
 		listFilebeats = &beatcrd.FilebeatList{}
-		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.env.name=%s", a.GetName()))
+		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.env.valueFrom.configMapKeyRef.name=%s", a.GetName()))
 		if err := c.List(context.Background(), listFilebeats, &client.ListOptions{Namespace: a.GetNamespace(), FieldSelector: fs}); err != nil {
 			panic(err)
 		}
@@ -225,7 +225,7 @@ func watchConfigMap(c client.Client) handler.MapFunc {
 
 		// EnvFrom of type secrets
 		listFilebeats = &beatcrd.FilebeatList{}
-		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.envFrom.name=%s", a.GetName()))
+		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.envFrom.configMapRef.name=%s", a.GetName()))
 		if err := c.List(context.Background(), listFilebeats, &client.ListOptions{Namespace: a.GetNamespace(), FieldSelector: fs}); err != nil {
 			panic(err)
 		}
@@ -280,7 +280,7 @@ func watchSecret(c client.Client) handler.MapFunc {
 
 		// Additional volumes secrets
 		listFilebeats = &beatcrd.FilebeatList{}
-		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.additionalVolumes.name=%s", a.GetName()))
+		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.additionalVolumes.secret.secretName=%s", a.GetName()))
 		if err := c.List(context.Background(), listFilebeats, &client.ListOptions{Namespace: a.GetNamespace(), FieldSelector: fs}); err != nil {
 			panic(err)
 		}
@@ -290,7 +290,7 @@ func watchSecret(c client.Client) handler.MapFunc {
 
 		// Env of type secrets
 		listFilebeats = &beatcrd.FilebeatList{}
-		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.env.name=%s", a.GetName()))
+		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.env.valueFrom.secretKeyRef.name=%s", a.GetName()))
 		if err := c.List(context.Background(), listFilebeats, &client.ListOptions{Namespace: a.GetNamespace(), FieldSelector: fs}); err != nil {
 			panic(err)
 		}
@@ -300,7 +300,7 @@ func watchSecret(c client.Client) handler.MapFunc {
 
 		// EnvFrom of type secrets
 		listFilebeats = &beatcrd.FilebeatList{}
-		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.envFrom.name=%s", a.GetName()))
+		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.envFrom.secretRef.name=%s", a.GetName()))
 		if err := c.List(context.Background(), listFilebeats, &client.ListOptions{Namespace: a.GetNamespace(), FieldSelector: fs}); err != nil {
 			panic(err)
 		}

--- a/controllers/kibana/kibana_controller.go
+++ b/controllers/kibana/kibana_controller.go
@@ -190,7 +190,7 @@ func watchConfigMap(c client.Client) handler.MapFunc {
 
 		// Env of type configMap
 		listKibanas = &kibanacrd.KibanaList{}
-		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.env.name=%s", a.GetName()))
+		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.env.valueFrom.configMapKeyRef.name=%s", a.GetName()))
 		if err := c.List(context.Background(), listKibanas, &client.ListOptions{Namespace: a.GetNamespace(), FieldSelector: fs}); err != nil {
 			panic(err)
 		}
@@ -200,7 +200,7 @@ func watchConfigMap(c client.Client) handler.MapFunc {
 
 		// EnvFrom of type configMap
 		listKibanas = &kibanacrd.KibanaList{}
-		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.envFrom.name=%s", a.GetName()))
+		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.envFrom.configMapRef.name=%s", a.GetName()))
 		if err := c.List(context.Background(), listKibanas, &client.ListOptions{Namespace: a.GetNamespace(), FieldSelector: fs}); err != nil {
 			panic(err)
 		}
@@ -267,7 +267,7 @@ func watchSecret(c client.Client) handler.MapFunc {
 
 		// Env of type secrets
 		listKibanas = &kibanacrd.KibanaList{}
-		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.env.name=%s", a.GetName()))
+		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.env.valueFrom.secretKeyRef.name=%s", a.GetName()))
 		if err := c.List(context.Background(), listKibanas, &client.ListOptions{Namespace: a.GetNamespace(), FieldSelector: fs}); err != nil {
 			panic(err)
 		}
@@ -277,7 +277,7 @@ func watchSecret(c client.Client) handler.MapFunc {
 
 		// EnvFrom of type secrets
 		listKibanas = &kibanacrd.KibanaList{}
-		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.envFrom.name=%s", a.GetName()))
+		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.envFrom.secretRef.name=%s", a.GetName()))
 		if err := c.List(context.Background(), listKibanas, &client.ListOptions{Namespace: a.GetNamespace(), FieldSelector: fs}); err != nil {
 			panic(err)
 		}

--- a/controllers/logstash/logstash_controller.go
+++ b/controllers/logstash/logstash_controller.go
@@ -183,7 +183,7 @@ func watchConfigMap(c client.Client) handler.MapFunc {
 
 		// Additional volumes secrets
 		listLogstashs = &logstashcrd.LogstashList{}
-		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.additionalVolumes.name=%s", a.GetName()))
+		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.additionalVolumes.configMap.name=%s", a.GetName()))
 		if err := c.List(context.Background(), listLogstashs, &client.ListOptions{Namespace: a.GetNamespace(), FieldSelector: fs}); err != nil {
 			panic(err)
 		}
@@ -193,7 +193,7 @@ func watchConfigMap(c client.Client) handler.MapFunc {
 
 		// Env of type secrets
 		listLogstashs = &logstashcrd.LogstashList{}
-		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.env.name=%s", a.GetName()))
+		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.env.valueFrom.configMapKeyRef.name=%s", a.GetName()))
 		if err := c.List(context.Background(), listLogstashs, &client.ListOptions{Namespace: a.GetNamespace(), FieldSelector: fs}); err != nil {
 			panic(err)
 		}
@@ -203,7 +203,7 @@ func watchConfigMap(c client.Client) handler.MapFunc {
 
 		// EnvFrom of type secrets
 		listLogstashs = &logstashcrd.LogstashList{}
-		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.envFrom.name=%s", a.GetName()))
+		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.envFrom.configMapRef.name=%s", a.GetName()))
 		if err := c.List(context.Background(), listLogstashs, &client.ListOptions{Namespace: a.GetNamespace(), FieldSelector: fs}); err != nil {
 			panic(err)
 		}
@@ -258,7 +258,7 @@ func watchSecret(c client.Client) handler.MapFunc {
 
 		// Additional volumes secrets
 		listLogstashs = &logstashcrd.LogstashList{}
-		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.additionalVolumes.name=%s", a.GetName()))
+		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.additionalVolumes.secret.secretName=%s", a.GetName()))
 		if err := c.List(context.Background(), listLogstashs, &client.ListOptions{Namespace: a.GetNamespace(), FieldSelector: fs}); err != nil {
 			panic(err)
 		}
@@ -268,7 +268,7 @@ func watchSecret(c client.Client) handler.MapFunc {
 
 		// Env of type secrets
 		listLogstashs = &logstashcrd.LogstashList{}
-		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.env.name=%s", a.GetName()))
+		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.env.valueFrom.secretKeyRef.name=%s", a.GetName()))
 		if err := c.List(context.Background(), listLogstashs, &client.ListOptions{Namespace: a.GetNamespace(), FieldSelector: fs}); err != nil {
 			panic(err)
 		}
@@ -278,7 +278,7 @@ func watchSecret(c client.Client) handler.MapFunc {
 
 		// EnvFrom of type secrets
 		listLogstashs = &logstashcrd.LogstashList{}
-		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.envFrom.name=%s", a.GetName()))
+		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.envFrom.secretRef.name=%s", a.GetName()))
 		if err := c.List(context.Background(), listLogstashs, &client.ListOptions{Namespace: a.GetNamespace(), FieldSelector: fs}); err != nil {
 			panic(err)
 		}

--- a/controllers/metricbeat/metricbeat_controller.go
+++ b/controllers/metricbeat/metricbeat_controller.go
@@ -170,7 +170,7 @@ func watchConfigMap(c client.Client) handler.MapFunc {
 
 		// Additional volumes secrets
 		listMetricbeats = &beatcrd.MetricbeatList{}
-		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.additionalVolumes.name=%s", a.GetName()))
+		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.additionalVolumes.configMap.name=%s", a.GetName()))
 		if err := c.List(context.Background(), listMetricbeats, &client.ListOptions{Namespace: a.GetNamespace(), FieldSelector: fs}); err != nil {
 			panic(err)
 		}
@@ -180,7 +180,7 @@ func watchConfigMap(c client.Client) handler.MapFunc {
 
 		// Env of type secrets
 		listMetricbeats = &beatcrd.MetricbeatList{}
-		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.env.name=%s", a.GetName()))
+		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.env.valueFrom.configMapKeyRef.name=%s", a.GetName()))
 		if err := c.List(context.Background(), listMetricbeats, &client.ListOptions{Namespace: a.GetNamespace(), FieldSelector: fs}); err != nil {
 			panic(err)
 		}
@@ -190,7 +190,7 @@ func watchConfigMap(c client.Client) handler.MapFunc {
 
 		// EnvFrom of type secrets
 		listMetricbeats = &beatcrd.MetricbeatList{}
-		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.envFrom.name=%s", a.GetName()))
+		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.envFrom.configMapRef.name=%s", a.GetName()))
 		if err := c.List(context.Background(), listMetricbeats, &client.ListOptions{Namespace: a.GetNamespace(), FieldSelector: fs}); err != nil {
 			panic(err)
 		}
@@ -235,7 +235,7 @@ func watchSecret(c client.Client) handler.MapFunc {
 
 		// Additional volumes secrets
 		listMetricbeats = &beatcrd.MetricbeatList{}
-		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.additionalVolumes.name=%s", a.GetName()))
+		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.additionalVolumes.secret.secretName=%s", a.GetName()))
 		if err := c.List(context.Background(), listMetricbeats, &client.ListOptions{Namespace: a.GetNamespace(), FieldSelector: fs}); err != nil {
 			panic(err)
 		}
@@ -245,7 +245,7 @@ func watchSecret(c client.Client) handler.MapFunc {
 
 		// Env of type secrets
 		listMetricbeats = &beatcrd.MetricbeatList{}
-		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.env.name=%s", a.GetName()))
+		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.env.valueFrom.secretKeyRef.name=%s", a.GetName()))
 		if err := c.List(context.Background(), listMetricbeats, &client.ListOptions{Namespace: a.GetNamespace(), FieldSelector: fs}); err != nil {
 			panic(err)
 		}
@@ -255,7 +255,7 @@ func watchSecret(c client.Client) handler.MapFunc {
 
 		// EnvFrom of type secrets
 		listMetricbeats = &beatcrd.MetricbeatList{}
-		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.envFrom.name=%s", a.GetName()))
+		fs = fields.ParseSelectorOrDie(fmt.Sprintf("spec.deployment.envFrom.secretRef.name=%s", a.GetName()))
 		if err := c.List(context.Background(), listMetricbeats, &client.ListOptions{Namespace: a.GetNamespace(), FieldSelector: fs}); err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Fix how to renew certificates on Elasticsearch
Fix indexers an watchers for env, envFrom and additionalVolumes

To manual force Elasticsearch renew certificate, add annotation `elasticsearch.k8s.webcenter.fr/renew-certificates: 'true'`