### PR TITLE
fix: fix issue #137. Set number of replica on metricbeat dedicated to monitor the stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.38
-PREVIOUS_VERSION ?= 0.0.37
+VERSION ?= 0.0.39
+PREVIOUS_VERSION ?= 0.0.38
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/apis/beat/v1/filebeat_types.go
+++ b/apis/beat/v1/filebeat_types.go
@@ -335,7 +335,7 @@ type FilebeatAntiAffinitySpec struct {
 
 	// Type permit to set anti affinity as soft or hard
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// +kubebuilder:validation:Enum=soft,hard
+	// +kubebuilder:validation:Enum=soft;hard
 	// +kubebuilder:default=soft
 	Type string `json:"type"`
 

--- a/apis/beat/v1/metricbeat_types.go
+++ b/apis/beat/v1/metricbeat_types.go
@@ -171,7 +171,7 @@ type MetricbeatAntiAffinitySpec struct {
 
 	// Type permit to set anti affinity as soft or hard
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// +kubebuilder:validation:Enum=soft,hard
+	// +kubebuilder:validation:Enum=soft;hard
 	// +kubebuilder:default=soft
 	Type string `json:"type"`
 

--- a/apis/elasticsearch/v1/elasticsearch_types.go
+++ b/apis/elasticsearch/v1/elasticsearch_types.go
@@ -422,7 +422,7 @@ type ElasticsearchNodeGroupSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +optional
 	// +kubebuilder:default=green
-	// +kubebuilder:validation:Enum=green,yellow,red
+	// +kubebuilder:validation:Enum=green;yellow;red
 	WaitClusterStatus string `json:"waitClusterStatus,omitempty"`
 }
 
@@ -454,7 +454,7 @@ type ElasticsearchAntiAffinitySpec struct {
 
 	// Type permit to set anti affinity as soft or hard
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// +kubebuilder:validation:Enum=soft,hard
+	// +kubebuilder:validation:Enum=soft;hard
 	// +kubebuilder:default=soft
 	// +optional
 	Type string `json:"type"`

--- a/apis/kibana/v1/kibana_types.go
+++ b/apis/kibana/v1/kibana_types.go
@@ -305,7 +305,7 @@ type KibanaAntiAffinitySpec struct {
 
 	// Type permit to set anti affinity as soft or hard
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// +kubebuilder:validation:Enum=soft,hard
+	// +kubebuilder:validation:Enum=soft;hard
 	// +kubebuilder:default=soft
 	Type string `json:"type"`
 

--- a/apis/logstash/v1/logstash_types.go
+++ b/apis/logstash/v1/logstash_types.go
@@ -302,7 +302,7 @@ type LogstashAntiAffinitySpec struct {
 
 	// Type permit to set anti affinity as soft or hard
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// +kubebuilder:validation:Enum=soft,hard
+	// +kubebuilder:validation:Enum=soft;hard
 	// +kubebuilder:default=soft
 	Type string `json:"type"`
 

--- a/apis/shared/image.go
+++ b/apis/shared/image.go
@@ -16,7 +16,7 @@ type ImageSpec struct {
 	// ImagePullPolicy is the image pull policy to use
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +kubebuilder:default=IfNotPresent
-	// +kubebuilder:validation:Enum=Always,Never,IfNotPresent
+	// +kubebuilder:validation:Enum=Always;Never;IfNotPresent
 	// +optional
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 

--- a/apis/shared/metricbeat_monitoring.go
+++ b/apis/shared/metricbeat_monitoring.go
@@ -33,4 +33,11 @@ type MetricbeatMonitoringSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +optional
 	Version string `json:"version,omitempty"`
+
+	// NumberOfReplica is the number of replica to set on metricbeat setting when it create templates
+	// Default is set to 0
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +optional
+	// +kubebuilder:default=0
+	NumberOfReplica int64 `json:"numberOfReplicas,omitempty"`
 }

--- a/bundle/manifests/beat.k8s.webcenter.fr_filebeats.yaml
+++ b/bundle/manifests/beat.k8s.webcenter.fr_filebeats.yaml
@@ -1731,12 +1731,16 @@ spec:
                     description: AntiAffinity permit to set anti affinity policy
                     properties:
                       topologyKey:
-                        default: topology.kubernetes.io/zone
+                        default: kubernetes.io/hostname
                         description: TopologyKey is the topology key to use Default
-                          to topology.kubernetes.io/zone
+                          to kubernetes.io/hostname
                         type: string
                       type:
+                        default: soft
                         description: Type permit to set anti affinity as soft or hard
+                        enum:
+                        - soft
+                        - hard
                         type: string
                     required:
                     - type
@@ -4146,7 +4150,12 @@ spec:
                   can be usefull to use internal registry or mirror
                 type: string
               imagePullPolicy:
+                default: IfNotPresent
                 description: ImagePullPolicy is the image pull policy to use
+                enum:
+                - Always
+                - Never
+                - IfNotPresent
                 type: string
               imagePullSecrets:
                 description: ImagePullSecrets is the image pull secrets to use
@@ -4621,7 +4630,19 @@ spec:
                         description: Enabled permit to enable Metricbeat monitoring
                           It will deploy metricbeat to collect metric Default to false
                         type: boolean
-                      initContainerResources:
+                      numberOfReplicas:
+                        default: 0
+                        description: NumberOfReplica is the number of replica to set
+                          on metricbeat setting when it create templates Default is
+                          set to 0
+                        format: int64
+                        type: integer
+                      refreshPeriod:
+                        default: 10s
+                        description: RefreshPeriod permit to set the time to collect
+                          data Defaullt to  `10s`
+                        type: string
+                      resources:
                         description: Resources permit to set resources on metricbeat
                         properties:
                           claims:
@@ -4670,11 +4691,6 @@ spec:
                               Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
-                      refreshPeriod:
-                        default: 10s
-                        description: RefreshPeriod permit to set the time to collect
-                          data Defaullt to  `10s`
-                        type: string
                       version:
                         description: Version is the Metricbeat version to use Default
                           it use the same version of the product that it monitor

--- a/bundle/manifests/beat.k8s.webcenter.fr_metricbeats.yaml
+++ b/bundle/manifests/beat.k8s.webcenter.fr_metricbeats.yaml
@@ -1731,12 +1731,16 @@ spec:
                     description: AntiAffinity permit to set anti affinity policy
                     properties:
                       topologyKey:
-                        default: topology.kubernetes.io/zone
+                        default: kubernetes.io/hostname
                         description: TopologyKey is the topology key to use Default
-                          to topology.kubernetes.io/zone
+                          to kubernetes.io/hostname
                         type: string
                       type:
+                        default: soft
                         description: Type permit to set anti affinity as soft or hard
+                        enum:
+                        - soft
+                        - hard
                         type: string
                     required:
                     - type
@@ -4109,7 +4113,12 @@ spec:
                   can be usefull to use internal registry or mirror
                 type: string
               imagePullPolicy:
+                default: IfNotPresent
                 description: ImagePullPolicy is the image pull policy to use
+                enum:
+                - Always
+                - Never
+                - IfNotPresent
                 type: string
               imagePullSecrets:
                 description: ImagePullSecrets is the image pull secrets to use

--- a/bundle/manifests/cerebro.k8s.webcenter.fr_cerebroes.yaml
+++ b/bundle/manifests/cerebro.k8s.webcenter.fr_cerebroes.yaml
@@ -679,7 +679,12 @@ spec:
                   can be usefull to use internal registry or mirror
                 type: string
               imagePullPolicy:
+                default: IfNotPresent
                 description: ImagePullPolicy is the image pull policy to use
+                enum:
+                - Always
+                - Never
+                - IfNotPresent
                 type: string
               imagePullSecrets:
                 description: ImagePullSecrets is the image pull secrets to use

--- a/bundle/manifests/elasticsearch-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/elasticsearch-operator.clusterserviceversion.yaml
@@ -936,10 +936,10 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-11-08T13:50:45Z"
+    createdAt: "2023-11-16T13:02:38Z"
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: elasticsearch-operator.v0.0.38
+  name: elasticsearch-operator.v0.0.39
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1094,7 +1094,7 @@ spec:
       - description: AntiAffinity permit to set anti affinity policy
         displayName: Anti Affinity
         path: globalNodeGroup.antiAffinity
-      - description: TopologyKey is the topology key to use Default to topology.kubernetes.io/zone
+      - description: TopologyKey is the topology key to use Default to kubernetes.io/hostname
         displayName: Topology Key
         path: globalNodeGroup.antiAffinity.topologyKey
       - description: Type permit to set anti affinity as soft or hard
@@ -1166,13 +1166,17 @@ spec:
           metricbeat to collect metric Default to false
         displayName: Enabled
         path: monitoring.metricbeat.enabled
-      - description: Resources permit to set resources on metricbeat
-        displayName: Resources
-        path: monitoring.metricbeat.initContainerResources
+      - description: NumberOfReplica is the number of replica to set on metricbeat
+          setting when it create templates Default is set to 0
+        displayName: Number Of Replica
+        path: monitoring.metricbeat.numberOfReplicas
       - description: RefreshPeriod permit to set the time to collect data Defaullt
           to  `10s`
         displayName: Refresh Period
         path: monitoring.metricbeat.refreshPeriod
+      - description: Resources permit to set resources on metricbeat
+        displayName: Resources
+        path: monitoring.metricbeat.resources
       - description: Version is the Metricbeat version to use Default it use the same
           version of the product that it monitor
         displayName: Version
@@ -1212,7 +1216,7 @@ spec:
       - description: AntiAffinity permit to set anti affinity policy
         displayName: Anti Affinity
         path: nodeGroups[0].antiAffinity
-      - description: TopologyKey is the topology key to use Default to topology.kubernetes.io/zone
+      - description: TopologyKey is the topology key to use Default to kubernetes.io/hostname
         displayName: Topology Key
         path: nodeGroups[0].antiAffinity.topologyKey
       - description: Type permit to set anti affinity as soft or hard
@@ -1380,7 +1384,7 @@ spec:
       - description: AntiAffinity permit to set anti affinity policy
         displayName: Anti Affinity
         path: deployment.antiAffinity
-      - description: TopologyKey is the topology key to use Default to topology.kubernetes.io/zone
+      - description: TopologyKey is the topology key to use Default to kubernetes.io/hostname
         displayName: Topology Key
         path: deployment.antiAffinity.topologyKey
       - description: Type permit to set anti affinity as soft or hard
@@ -1535,13 +1539,17 @@ spec:
           metricbeat to collect metric Default to false
         displayName: Enabled
         path: monitoring.metricbeat.enabled
-      - description: Resources permit to set resources on metricbeat
-        displayName: Resources
-        path: monitoring.metricbeat.initContainerResources
+      - description: NumberOfReplica is the number of replica to set on metricbeat
+          setting when it create templates Default is set to 0
+        displayName: Number Of Replica
+        path: monitoring.metricbeat.numberOfReplicas
       - description: RefreshPeriod permit to set the time to collect data Defaullt
           to  `10s`
         displayName: Refresh Period
         path: monitoring.metricbeat.refreshPeriod
+      - description: Resources permit to set resources on metricbeat
+        displayName: Resources
+        path: monitoring.metricbeat.resources
       - description: Version is the Metricbeat version to use Default it use the same
           version of the product that it monitor
         displayName: Version
@@ -1742,7 +1750,7 @@ spec:
       - description: AntiAffinity permit to set anti affinity policy
         displayName: Anti Affinity
         path: deployment.antiAffinity
-      - description: TopologyKey is the topology key to use Default to topology.kubernetes.io/zone
+      - description: TopologyKey is the topology key to use Default to kubernetes.io/hostname
         displayName: Topology Key
         path: deployment.antiAffinity.topologyKey
       - description: Type permit to set anti affinity as soft or hard
@@ -1859,13 +1867,17 @@ spec:
           metricbeat to collect metric Default to false
         displayName: Enabled
         path: monitoring.metricbeat.enabled
-      - description: Resources permit to set resources on metricbeat
-        displayName: Resources
-        path: monitoring.metricbeat.initContainerResources
+      - description: NumberOfReplica is the number of replica to set on metricbeat
+          setting when it create templates Default is set to 0
+        displayName: Number Of Replica
+        path: monitoring.metricbeat.numberOfReplicas
       - description: RefreshPeriod permit to set the time to collect data Defaullt
           to  `10s`
         displayName: Refresh Period
         path: monitoring.metricbeat.refreshPeriod
+      - description: Resources permit to set resources on metricbeat
+        displayName: Resources
+        path: monitoring.metricbeat.resources
       - description: Version is the Metricbeat version to use Default it use the same
           version of the product that it monitor
         displayName: Version
@@ -2014,7 +2026,7 @@ spec:
       - description: AntiAffinity permit to set anti affinity policy
         displayName: Anti Affinity
         path: deployment.antiAffinity
-      - description: TopologyKey is the topology key to use Default to topology.kubernetes.io/zone
+      - description: TopologyKey is the topology key to use Default to kubernetes.io/hostname
         displayName: Topology Key
         path: deployment.antiAffinity.topologyKey
       - description: Type permit to set anti affinity as soft or hard
@@ -2140,13 +2152,17 @@ spec:
           metricbeat to collect metric Default to false
         displayName: Enabled
         path: monitoring.metricbeat.enabled
-      - description: Resources permit to set resources on metricbeat
-        displayName: Resources
-        path: monitoring.metricbeat.initContainerResources
+      - description: NumberOfReplica is the number of replica to set on metricbeat
+          setting when it create templates Default is set to 0
+        displayName: Number Of Replica
+        path: monitoring.metricbeat.numberOfReplicas
       - description: RefreshPeriod permit to set the time to collect data Defaullt
           to  `10s`
         displayName: Refresh Period
         path: monitoring.metricbeat.refreshPeriod
+      - description: Resources permit to set resources on metricbeat
+        displayName: Resources
+        path: monitoring.metricbeat.resources
       - description: Version is the Metricbeat version to use Default it use the same
           version of the product that it monitor
         displayName: Version
@@ -2284,7 +2300,7 @@ spec:
       - description: AntiAffinity permit to set anti affinity policy
         displayName: Anti Affinity
         path: deployment.antiAffinity
-      - description: TopologyKey is the topology key to use Default to topology.kubernetes.io/zone
+      - description: TopologyKey is the topology key to use Default to kubernetes.io/hostname
         displayName: Topology Key
         path: deployment.antiAffinity.topologyKey
       - description: Type permit to set anti affinity as soft or hard
@@ -2452,7 +2468,7 @@ spec:
       - description: Indices is the list of indices permissions
         displayName: Indices
         path: indices
-      - description: Allow to manage restricted index
+      - description: Allow to manage restricted index Default to false
         displayName: Allow Restricted Indices
         path: indices[0].allowRestrictedIndices
       - description: FieldSecurity JSON string
@@ -2512,7 +2528,7 @@ spec:
         path: elasticsearch.indices[0].query
       - description: RunAs is the privilege like users
         displayName: Run As
-        path: elasticsearch.run_as
+        path: elasticsearch.runAs
       - description: Kibana is the Kibana right
         displayName: Kibana
         path: kibana
@@ -2550,7 +2566,10 @@ spec:
         path: name
       - description: TransientMedata
         displayName: Transient Medata
-        path: transient_metadata
+        path: transientMetadata
+      - description: Enabled permit to enable transient metadata
+        displayName: Enabled
+        path: transientMetadata.enabled
       version: v1
     - description: SnapshotLifecyclePolicy is the Schema for the snapshotlifecyclepolicies
         API
@@ -2781,15 +2800,15 @@ spec:
           Default to false
         displayName: Create New Copies
         path: userSpaceCopies[0].createNewCopies
-      - description: CreateNewCopies is set to true to create new copy of objects
-          Default to false
+      - description: ForceUpdateWhenReconcile is set to true to force to sync objects
+          each time the operator reconcile Default to false
         displayName: Force Update When Reconcile
         path: userSpaceCopies[0].forceUpdate
       - description: IncludeReferences is set to true to copy all references Default
           to true
         displayName: Include References
         path: userSpaceCopies[0].includeReferences
-      - description: OriginUserSpace is the user space name from copy objects
+      - description: KibanaObjects is the list of object to copy
         displayName: Kibana Objects
         path: userSpaceCopies[0].objects
       - description: ID is the object to copy
@@ -3603,7 +3622,7 @@ spec:
                   value: INFO
                 - name: LOG_FORMATTER
                   value: json
-                image: quay.io/webcenter/elasticsearch-operator:0.0.38
+                image: quay.io/webcenter/elasticsearch-operator:0.0.39
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -3693,5 +3712,5 @@ spec:
   provider:
     name: webcenter.fr
     url: https://github.com/webcenter-fr/elasticsearch-operator
-  replaces: elasticsearch-operator.v0.0.37
-  version: 0.0.38
+  replaces: elasticsearch-operator.v0.0.38
+  version: 0.0.39

--- a/bundle/manifests/elasticsearch.k8s.webcenter.fr_elasticsearches.yaml
+++ b/bundle/manifests/elasticsearch.k8s.webcenter.fr_elasticsearches.yaml
@@ -2091,15 +2091,17 @@ spec:
                     description: AntiAffinity permit to set anti affinity policy
                     properties:
                       topologyKey:
-                        default: topology.kubernetes.io/zone
+                        default: kubernetes.io/hostname
                         description: TopologyKey is the topology key to use Default
-                          to topology.kubernetes.io/zone
+                          to kubernetes.io/hostname
                         type: string
                       type:
+                        default: soft
                         description: Type permit to set anti affinity as soft or hard
+                        enum:
+                        - soft
+                        - hard
                         type: string
-                    required:
-                    - type
                     type: object
                   caSecretRef:
                     description: CacertsSecretRef is the secret that store custom
@@ -2449,7 +2451,12 @@ spec:
                   can be usefull to use internal registry or mirror
                 type: string
               imagePullPolicy:
+                default: IfNotPresent
                 description: ImagePullPolicy is the image pull policy to use
+                enum:
+                - Always
+                - Never
+                - IfNotPresent
                 type: string
               imagePullSecrets:
                 description: ImagePullSecrets is the image pull secrets to use
@@ -2553,7 +2560,19 @@ spec:
                         description: Enabled permit to enable Metricbeat monitoring
                           It will deploy metricbeat to collect metric Default to false
                         type: boolean
-                      initContainerResources:
+                      numberOfReplicas:
+                        default: 0
+                        description: NumberOfReplica is the number of replica to set
+                          on metricbeat setting when it create templates Default is
+                          set to 0
+                        format: int64
+                        type: integer
+                      refreshPeriod:
+                        default: 10s
+                        description: RefreshPeriod permit to set the time to collect
+                          data Defaullt to  `10s`
+                        type: string
+                      resources:
                         description: Resources permit to set resources on metricbeat
                         properties:
                           claims:
@@ -2602,11 +2621,6 @@ spec:
                               Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
-                      refreshPeriod:
-                        default: 10s
-                        description: RefreshPeriod permit to set the time to collect
-                          data Defaullt to  `10s`
-                        type: string
                       version:
                         description: Version is the Metricbeat version to use Default
                           it use the same version of the product that it monitor
@@ -2627,7 +2641,12 @@ spec:
                           It can be usefull to use internal registry or mirror
                         type: string
                       imagePullPolicy:
+                        default: IfNotPresent
                         description: ImagePullPolicy is the image pull policy to use
+                        enum:
+                        - Always
+                        - Never
+                        - IfNotPresent
                         type: string
                       imagePullSecrets:
                         description: ImagePullSecrets is the image pull secrets to
@@ -2716,16 +2735,18 @@ spec:
                       description: AntiAffinity permit to set anti affinity policy
                       properties:
                         topologyKey:
-                          default: topology.kubernetes.io/zone
+                          default: kubernetes.io/hostname
                           description: TopologyKey is the topology key to use Default
-                            to topology.kubernetes.io/zone
+                            to kubernetes.io/hostname
                           type: string
                         type:
+                          default: soft
                           description: Type permit to set anti affinity as soft or
                             hard
+                          enum:
+                          - soft
+                          - hard
                           type: string
-                      required:
-                      - type
                       type: object
                     config:
                       additionalProperties:
@@ -5048,6 +5069,10 @@ spec:
                       default: green
                       description: WaitClusterStatus permit to wait the cluster state
                         on readyness probe Default to green
+                      enum:
+                      - green
+                      - yellow
+                      - red
                       type: string
                   required:
                   - name

--- a/bundle/manifests/elasticsearchapi.k8s.webcenter.fr_roles.yaml
+++ b/bundle/manifests/elasticsearchapi.k8s.webcenter.fr_roles.yaml
@@ -148,7 +148,7 @@ spec:
                     object
                   properties:
                     allowRestrictedIndices:
-                      description: Allow to manage restricted index
+                      description: Allow to manage restricted index Default to false
                       type: boolean
                     fieldSecurity:
                       description: FieldSecurity JSON string

--- a/bundle/manifests/kibana.k8s.webcenter.fr_kibanas.yaml
+++ b/bundle/manifests/kibana.k8s.webcenter.fr_kibanas.yaml
@@ -71,12 +71,16 @@ spec:
                     description: AntiAffinity permit to set anti affinity policy
                     properties:
                       topologyKey:
-                        default: topology.kubernetes.io/zone
+                        default: kubernetes.io/hostname
                         description: TopologyKey is the topology key to use Default
-                          to topology.kubernetes.io/zone
+                          to kubernetes.io/hostname
                         type: string
                       type:
+                        default: soft
                         description: Type permit to set anti affinity as soft or hard
+                        enum:
+                        - soft
+                        - hard
                         type: string
                     required:
                     - type
@@ -903,7 +907,12 @@ spec:
                   can be usefull to use internal registry or mirror
                 type: string
               imagePullPolicy:
+                default: IfNotPresent
                 description: ImagePullPolicy is the image pull policy to use
+                enum:
+                - Always
+                - Never
+                - IfNotPresent
                 type: string
               imagePullSecrets:
                 description: ImagePullSecrets is the image pull secrets to use
@@ -1007,7 +1016,19 @@ spec:
                         description: Enabled permit to enable Metricbeat monitoring
                           It will deploy metricbeat to collect metric Default to false
                         type: boolean
-                      initContainerResources:
+                      numberOfReplicas:
+                        default: 0
+                        description: NumberOfReplica is the number of replica to set
+                          on metricbeat setting when it create templates Default is
+                          set to 0
+                        format: int64
+                        type: integer
+                      refreshPeriod:
+                        default: 10s
+                        description: RefreshPeriod permit to set the time to collect
+                          data Defaullt to  `10s`
+                        type: string
+                      resources:
                         description: Resources permit to set resources on metricbeat
                         properties:
                           claims:
@@ -1056,11 +1077,6 @@ spec:
                               Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
-                      refreshPeriod:
-                        default: 10s
-                        description: RefreshPeriod permit to set the time to collect
-                          data Defaullt to  `10s`
-                        type: string
                       version:
                         description: Version is the Metricbeat version to use Default
                           it use the same version of the product that it monitor

--- a/bundle/manifests/kibanaapi.k8s.webcenter.fr_roles.yaml
+++ b/bundle/manifests/kibanaapi.k8s.webcenter.fr_roles.yaml
@@ -82,7 +82,7 @@ spec:
                       - privileges
                       type: object
                     type: array
-                  run_as:
+                  runAs:
                     description: RunAs is the privilege like users
                     items:
                       type: string
@@ -169,10 +169,11 @@ spec:
                 description: Name is the role name If empty, it use the ressource
                   name
                 type: string
-              transient_metadata:
+              transientMetadata:
                 description: TransientMedata
                 properties:
                   enabled:
+                    description: Enabled permit to enable transient metadata
                     type: boolean
                 type: object
             required:

--- a/bundle/manifests/kibanaapi.k8s.webcenter.fr_userspaces.yaml
+++ b/bundle/manifests/kibanaapi.k8s.webcenter.fr_userspaces.yaml
@@ -131,16 +131,16 @@ spec:
                         of objects Default to false
                       type: boolean
                     forceUpdate:
-                      description: CreateNewCopies is set to true to create new copy
-                        of objects Default to false
+                      description: ForceUpdateWhenReconcile is set to true to force
+                        to sync objects each time the operator reconcile Default to
+                        false
                       type: boolean
                     includeReferences:
                       description: IncludeReferences is set to true to copy all references
                         Default to true
                       type: boolean
                     objects:
-                      description: OriginUserSpace is the user space name from copy
-                        objects
+                      description: KibanaObjects is the list of object to copy
                       items:
                         properties:
                           id:

--- a/bundle/manifests/logstash.k8s.webcenter.fr_logstashes.yaml
+++ b/bundle/manifests/logstash.k8s.webcenter.fr_logstashes.yaml
@@ -1731,12 +1731,16 @@ spec:
                     description: AntiAffinity permit to set anti affinity policy
                     properties:
                       topologyKey:
-                        default: topology.kubernetes.io/zone
+                        default: kubernetes.io/hostname
                         description: TopologyKey is the topology key to use Default
-                          to topology.kubernetes.io/zone
+                          to kubernetes.io/hostname
                         type: string
                       type:
+                        default: soft
                         description: Type permit to set anti affinity as soft or hard
+                        enum:
+                        - soft
+                        - hard
                         type: string
                     required:
                     - type
@@ -4149,7 +4153,12 @@ spec:
                   can be usefull to use internal registry or mirror
                 type: string
               imagePullPolicy:
+                default: IfNotPresent
                 description: ImagePullPolicy is the image pull policy to use
+                enum:
+                - Always
+                - Never
+                - IfNotPresent
                 type: string
               imagePullSecrets:
                 description: ImagePullSecrets is the image pull secrets to use
@@ -4576,7 +4585,19 @@ spec:
                         description: Enabled permit to enable Metricbeat monitoring
                           It will deploy metricbeat to collect metric Default to false
                         type: boolean
-                      initContainerResources:
+                      numberOfReplicas:
+                        default: 0
+                        description: NumberOfReplica is the number of replica to set
+                          on metricbeat setting when it create templates Default is
+                          set to 0
+                        format: int64
+                        type: integer
+                      refreshPeriod:
+                        default: 10s
+                        description: RefreshPeriod permit to set the time to collect
+                          data Defaullt to  `10s`
+                        type: string
+                      resources:
                         description: Resources permit to set resources on metricbeat
                         properties:
                           claims:
@@ -4625,11 +4646,6 @@ spec:
                               Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
-                      refreshPeriod:
-                        default: 10s
-                        description: RefreshPeriod permit to set the time to collect
-                          data Defaullt to  `10s`
-                        type: string
                       version:
                         description: Version is the Metricbeat version to use Default
                           it use the same version of the product that it monitor

--- a/config/crd/bases/beat.k8s.webcenter.fr_filebeats.yaml
+++ b/config/crd/bases/beat.k8s.webcenter.fr_filebeats.yaml
@@ -1731,12 +1731,16 @@ spec:
                     description: AntiAffinity permit to set anti affinity policy
                     properties:
                       topologyKey:
-                        default: topology.kubernetes.io/zone
+                        default: kubernetes.io/hostname
                         description: TopologyKey is the topology key to use Default
-                          to topology.kubernetes.io/zone
+                          to kubernetes.io/hostname
                         type: string
                       type:
+                        default: soft
                         description: Type permit to set anti affinity as soft or hard
+                        enum:
+                        - soft
+                        - hard
                         type: string
                     required:
                     - type
@@ -12063,7 +12067,12 @@ spec:
                   can be usefull to use internal registry or mirror
                 type: string
               imagePullPolicy:
+                default: IfNotPresent
                 description: ImagePullPolicy is the image pull policy to use
+                enum:
+                - Always
+                - Never
+                - IfNotPresent
                 type: string
               imagePullSecrets:
                 description: ImagePullSecrets is the image pull secrets to use
@@ -12538,7 +12547,19 @@ spec:
                         description: Enabled permit to enable Metricbeat monitoring
                           It will deploy metricbeat to collect metric Default to false
                         type: boolean
-                      initContainerResources:
+                      numberOfReplicas:
+                        default: 0
+                        description: NumberOfReplica is the number of replica to set
+                          on metricbeat setting when it create templates Default is
+                          set to 0
+                        format: int64
+                        type: integer
+                      refreshPeriod:
+                        default: 10s
+                        description: RefreshPeriod permit to set the time to collect
+                          data Defaullt to  `10s`
+                        type: string
+                      resources:
                         description: Resources permit to set resources on metricbeat
                         properties:
                           claims:
@@ -12587,11 +12608,6 @@ spec:
                               Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
-                      refreshPeriod:
-                        default: 10s
-                        description: RefreshPeriod permit to set the time to collect
-                          data Defaullt to  `10s`
-                        type: string
                       version:
                         description: Version is the Metricbeat version to use Default
                           it use the same version of the product that it monitor

--- a/config/crd/bases/beat.k8s.webcenter.fr_metricbeats.yaml
+++ b/config/crd/bases/beat.k8s.webcenter.fr_metricbeats.yaml
@@ -1731,12 +1731,16 @@ spec:
                     description: AntiAffinity permit to set anti affinity policy
                     properties:
                       topologyKey:
-                        default: topology.kubernetes.io/zone
+                        default: kubernetes.io/hostname
                         description: TopologyKey is the topology key to use Default
-                          to topology.kubernetes.io/zone
+                          to kubernetes.io/hostname
                         type: string
                       type:
+                        default: soft
                         description: Type permit to set anti affinity as soft or hard
+                        enum:
+                        - soft
+                        - hard
                         type: string
                     required:
                     - type
@@ -12026,7 +12030,12 @@ spec:
                   can be usefull to use internal registry or mirror
                 type: string
               imagePullPolicy:
+                default: IfNotPresent
                 description: ImagePullPolicy is the image pull policy to use
+                enum:
+                - Always
+                - Never
+                - IfNotPresent
                 type: string
               imagePullSecrets:
                 description: ImagePullSecrets is the image pull secrets to use

--- a/config/crd/bases/cerebro.k8s.webcenter.fr_cerebroes.yaml
+++ b/config/crd/bases/cerebro.k8s.webcenter.fr_cerebroes.yaml
@@ -8596,7 +8596,12 @@ spec:
                   can be usefull to use internal registry or mirror
                 type: string
               imagePullPolicy:
+                default: IfNotPresent
                 description: ImagePullPolicy is the image pull policy to use
+                enum:
+                - Always
+                - Never
+                - IfNotPresent
                 type: string
               imagePullSecrets:
                 description: ImagePullSecrets is the image pull secrets to use

--- a/config/crd/bases/elasticsearch.k8s.webcenter.fr_elasticsearches.yaml
+++ b/config/crd/bases/elasticsearch.k8s.webcenter.fr_elasticsearches.yaml
@@ -2091,15 +2091,17 @@ spec:
                     description: AntiAffinity permit to set anti affinity policy
                     properties:
                       topologyKey:
-                        default: topology.kubernetes.io/zone
+                        default: kubernetes.io/hostname
                         description: TopologyKey is the topology key to use Default
-                          to topology.kubernetes.io/zone
+                          to kubernetes.io/hostname
                         type: string
                       type:
+                        default: soft
                         description: Type permit to set anti affinity as soft or hard
+                        enum:
+                        - soft
+                        - hard
                         type: string
-                    required:
-                    - type
                     type: object
                   caSecretRef:
                     description: CacertsSecretRef is the secret that store custom
@@ -10366,7 +10368,12 @@ spec:
                   can be usefull to use internal registry or mirror
                 type: string
               imagePullPolicy:
+                default: IfNotPresent
                 description: ImagePullPolicy is the image pull policy to use
+                enum:
+                - Always
+                - Never
+                - IfNotPresent
                 type: string
               imagePullSecrets:
                 description: ImagePullSecrets is the image pull secrets to use
@@ -10470,7 +10477,19 @@ spec:
                         description: Enabled permit to enable Metricbeat monitoring
                           It will deploy metricbeat to collect metric Default to false
                         type: boolean
-                      initContainerResources:
+                      numberOfReplicas:
+                        default: 0
+                        description: NumberOfReplica is the number of replica to set
+                          on metricbeat setting when it create templates Default is
+                          set to 0
+                        format: int64
+                        type: integer
+                      refreshPeriod:
+                        default: 10s
+                        description: RefreshPeriod permit to set the time to collect
+                          data Defaullt to  `10s`
+                        type: string
+                      resources:
                         description: Resources permit to set resources on metricbeat
                         properties:
                           claims:
@@ -10519,11 +10538,6 @@ spec:
                               Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
-                      refreshPeriod:
-                        default: 10s
-                        description: RefreshPeriod permit to set the time to collect
-                          data Defaullt to  `10s`
-                        type: string
                       version:
                         description: Version is the Metricbeat version to use Default
                           it use the same version of the product that it monitor
@@ -10544,7 +10558,12 @@ spec:
                           It can be usefull to use internal registry or mirror
                         type: string
                       imagePullPolicy:
+                        default: IfNotPresent
                         description: ImagePullPolicy is the image pull policy to use
+                        enum:
+                        - Always
+                        - Never
+                        - IfNotPresent
                         type: string
                       imagePullSecrets:
                         description: ImagePullSecrets is the image pull secrets to
@@ -10633,16 +10652,18 @@ spec:
                       description: AntiAffinity permit to set anti affinity policy
                       properties:
                         topologyKey:
-                          default: topology.kubernetes.io/zone
+                          default: kubernetes.io/hostname
                           description: TopologyKey is the topology key to use Default
-                            to topology.kubernetes.io/zone
+                            to kubernetes.io/hostname
                           type: string
                         type:
+                          default: soft
                           description: Type permit to set anti affinity as soft or
                             hard
+                          enum:
+                          - soft
+                          - hard
                           type: string
-                      required:
-                      - type
                       type: object
                     config:
                       additionalProperties:
@@ -21095,6 +21116,10 @@ spec:
                       default: green
                       description: WaitClusterStatus permit to wait the cluster state
                         on readyness probe Default to green
+                      enum:
+                      - green
+                      - yellow
+                      - red
                       type: string
                   required:
                   - name

--- a/config/crd/bases/elasticsearchapi.k8s.webcenter.fr_roles.yaml
+++ b/config/crd/bases/elasticsearchapi.k8s.webcenter.fr_roles.yaml
@@ -148,7 +148,7 @@ spec:
                     object
                   properties:
                     allowRestrictedIndices:
-                      description: Allow to manage restricted index
+                      description: Allow to manage restricted index Default to false
                       type: boolean
                     fieldSecurity:
                       description: FieldSecurity JSON string

--- a/config/crd/bases/kibana.k8s.webcenter.fr_kibanas.yaml
+++ b/config/crd/bases/kibana.k8s.webcenter.fr_kibanas.yaml
@@ -71,12 +71,16 @@ spec:
                     description: AntiAffinity permit to set anti affinity policy
                     properties:
                       topologyKey:
-                        default: topology.kubernetes.io/zone
+                        default: kubernetes.io/hostname
                         description: TopologyKey is the topology key to use Default
-                          to topology.kubernetes.io/zone
+                          to kubernetes.io/hostname
                         type: string
                       type:
+                        default: soft
                         description: Type permit to set anti affinity as soft or hard
+                        enum:
+                        - soft
+                        - hard
                         type: string
                     required:
                     - type
@@ -8820,7 +8824,12 @@ spec:
                   can be usefull to use internal registry or mirror
                 type: string
               imagePullPolicy:
+                default: IfNotPresent
                 description: ImagePullPolicy is the image pull policy to use
+                enum:
+                - Always
+                - Never
+                - IfNotPresent
                 type: string
               imagePullSecrets:
                 description: ImagePullSecrets is the image pull secrets to use
@@ -8924,7 +8933,19 @@ spec:
                         description: Enabled permit to enable Metricbeat monitoring
                           It will deploy metricbeat to collect metric Default to false
                         type: boolean
-                      initContainerResources:
+                      numberOfReplicas:
+                        default: 0
+                        description: NumberOfReplica is the number of replica to set
+                          on metricbeat setting when it create templates Default is
+                          set to 0
+                        format: int64
+                        type: integer
+                      refreshPeriod:
+                        default: 10s
+                        description: RefreshPeriod permit to set the time to collect
+                          data Defaullt to  `10s`
+                        type: string
+                      resources:
                         description: Resources permit to set resources on metricbeat
                         properties:
                           claims:
@@ -8973,11 +8994,6 @@ spec:
                               Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
-                      refreshPeriod:
-                        default: 10s
-                        description: RefreshPeriod permit to set the time to collect
-                          data Defaullt to  `10s`
-                        type: string
                       version:
                         description: Version is the Metricbeat version to use Default
                           it use the same version of the product that it monitor

--- a/config/crd/bases/kibanaapi.k8s.webcenter.fr_roles.yaml
+++ b/config/crd/bases/kibanaapi.k8s.webcenter.fr_roles.yaml
@@ -82,7 +82,7 @@ spec:
                       - privileges
                       type: object
                     type: array
-                  run_as:
+                  runAs:
                     description: RunAs is the privilege like users
                     items:
                       type: string
@@ -169,10 +169,11 @@ spec:
                 description: Name is the role name If empty, it use the ressource
                   name
                 type: string
-              transient_metadata:
+              transientMetadata:
                 description: TransientMedata
                 properties:
                   enabled:
+                    description: Enabled permit to enable transient metadata
                     type: boolean
                 type: object
             required:

--- a/config/crd/bases/kibanaapi.k8s.webcenter.fr_userspaces.yaml
+++ b/config/crd/bases/kibanaapi.k8s.webcenter.fr_userspaces.yaml
@@ -131,16 +131,16 @@ spec:
                         of objects Default to false
                       type: boolean
                     forceUpdate:
-                      description: CreateNewCopies is set to true to create new copy
-                        of objects Default to false
+                      description: ForceUpdateWhenReconcile is set to true to force
+                        to sync objects each time the operator reconcile Default to
+                        false
                       type: boolean
                     includeReferences:
                       description: IncludeReferences is set to true to copy all references
                         Default to true
                       type: boolean
                     objects:
-                      description: OriginUserSpace is the user space name from copy
-                        objects
+                      description: KibanaObjects is the list of object to copy
                       items:
                         properties:
                           id:

--- a/config/crd/bases/logstash.k8s.webcenter.fr_logstashes.yaml
+++ b/config/crd/bases/logstash.k8s.webcenter.fr_logstashes.yaml
@@ -1731,12 +1731,16 @@ spec:
                     description: AntiAffinity permit to set anti affinity policy
                     properties:
                       topologyKey:
-                        default: topology.kubernetes.io/zone
+                        default: kubernetes.io/hostname
                         description: TopologyKey is the topology key to use Default
-                          to topology.kubernetes.io/zone
+                          to kubernetes.io/hostname
                         type: string
                       type:
+                        default: soft
                         description: Type permit to set anti affinity as soft or hard
+                        enum:
+                        - soft
+                        - hard
                         type: string
                     required:
                     - type
@@ -12066,7 +12070,12 @@ spec:
                   can be usefull to use internal registry or mirror
                 type: string
               imagePullPolicy:
+                default: IfNotPresent
                 description: ImagePullPolicy is the image pull policy to use
+                enum:
+                - Always
+                - Never
+                - IfNotPresent
                 type: string
               imagePullSecrets:
                 description: ImagePullSecrets is the image pull secrets to use
@@ -12493,7 +12502,19 @@ spec:
                         description: Enabled permit to enable Metricbeat monitoring
                           It will deploy metricbeat to collect metric Default to false
                         type: boolean
-                      initContainerResources:
+                      numberOfReplicas:
+                        default: 0
+                        description: NumberOfReplica is the number of replica to set
+                          on metricbeat setting when it create templates Default is
+                          set to 0
+                        format: int64
+                        type: integer
+                      refreshPeriod:
+                        default: 10s
+                        description: RefreshPeriod permit to set the time to collect
+                          data Defaullt to  `10s`
+                        type: string
+                      resources:
                         description: Resources permit to set resources on metricbeat
                         properties:
                           claims:
@@ -12542,11 +12563,6 @@ spec:
                               Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
-                      refreshPeriod:
-                        default: 10s
-                        description: RefreshPeriod permit to set the time to collect
-                          data Defaullt to  `10s`
-                        type: string
                       version:
                         description: Version is the Metricbeat version to use Default
                           it use the same version of the product that it monitor

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/webcenter/elasticsearch-operator
-  newTag: 0.0.38
+  newTag: 0.0.39

--- a/config/manifests/bases/elasticsearch-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/elasticsearch-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-  name: elasticsearch-operator.v0.0.38
+  name: elasticsearch-operator.v0.0.39
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -2429,7 +2429,7 @@ spec:
       - description: AntiAffinity permit to set anti affinity policy
         displayName: Anti Affinity
         path: globalNodeGroup.antiAffinity
-      - description: TopologyKey is the topology key to use Default to topology.kubernetes.io/zone
+      - description: TopologyKey is the topology key to use Default to kubernetes.io/hostname
         displayName: Topology Key
         path: globalNodeGroup.antiAffinity.topologyKey
       - description: Type permit to set anti affinity as soft or hard
@@ -2501,13 +2501,17 @@ spec:
           metricbeat to collect metric Default to false
         displayName: Enabled
         path: monitoring.metricbeat.enabled
-      - description: Resources permit to set resources on metricbeat
-        displayName: Resources
-        path: monitoring.metricbeat.initContainerResources
+      - description: NumberOfReplica is the number of replica to set on metricbeat
+          setting when it create templates Default is set to 0
+        displayName: Number Of Replica
+        path: monitoring.metricbeat.numberOfReplicas
       - description: RefreshPeriod permit to set the time to collect data Defaullt
           to  `10s`
         displayName: Refresh Period
         path: monitoring.metricbeat.refreshPeriod
+      - description: Resources permit to set resources on metricbeat
+        displayName: Resources
+        path: monitoring.metricbeat.resources
       - description: Version is the Metricbeat version to use Default it use the same
           version of the product that it monitor
         displayName: Version
@@ -2547,7 +2551,7 @@ spec:
       - description: AntiAffinity permit to set anti affinity policy
         displayName: Anti Affinity
         path: nodeGroups[0].antiAffinity
-      - description: TopologyKey is the topology key to use Default to topology.kubernetes.io/zone
+      - description: TopologyKey is the topology key to use Default to kubernetes.io/hostname
         displayName: Topology Key
         path: nodeGroups[0].antiAffinity.topologyKey
       - description: Type permit to set anti affinity as soft or hard
@@ -2715,7 +2719,7 @@ spec:
       - description: AntiAffinity permit to set anti affinity policy
         displayName: Anti Affinity
         path: deployment.antiAffinity
-      - description: TopologyKey is the topology key to use Default to topology.kubernetes.io/zone
+      - description: TopologyKey is the topology key to use Default to kubernetes.io/hostname
         displayName: Topology Key
         path: deployment.antiAffinity.topologyKey
       - description: Type permit to set anti affinity as soft or hard
@@ -2870,13 +2874,17 @@ spec:
           metricbeat to collect metric Default to false
         displayName: Enabled
         path: monitoring.metricbeat.enabled
-      - description: Resources permit to set resources on metricbeat
-        displayName: Resources
-        path: monitoring.metricbeat.initContainerResources
+      - description: NumberOfReplica is the number of replica to set on metricbeat
+          setting when it create templates Default is set to 0
+        displayName: Number Of Replica
+        path: monitoring.metricbeat.numberOfReplicas
       - description: RefreshPeriod permit to set the time to collect data Defaullt
           to  `10s`
         displayName: Refresh Period
         path: monitoring.metricbeat.refreshPeriod
+      - description: Resources permit to set resources on metricbeat
+        displayName: Resources
+        path: monitoring.metricbeat.resources
       - description: Version is the Metricbeat version to use Default it use the same
           version of the product that it monitor
         displayName: Version
@@ -3077,7 +3085,7 @@ spec:
       - description: AntiAffinity permit to set anti affinity policy
         displayName: Anti Affinity
         path: deployment.antiAffinity
-      - description: TopologyKey is the topology key to use Default to topology.kubernetes.io/zone
+      - description: TopologyKey is the topology key to use Default to kubernetes.io/hostname
         displayName: Topology Key
         path: deployment.antiAffinity.topologyKey
       - description: Type permit to set anti affinity as soft or hard
@@ -3194,13 +3202,17 @@ spec:
           metricbeat to collect metric Default to false
         displayName: Enabled
         path: monitoring.metricbeat.enabled
-      - description: Resources permit to set resources on metricbeat
-        displayName: Resources
-        path: monitoring.metricbeat.initContainerResources
+      - description: NumberOfReplica is the number of replica to set on metricbeat
+          setting when it create templates Default is set to 0
+        displayName: Number Of Replica
+        path: monitoring.metricbeat.numberOfReplicas
       - description: RefreshPeriod permit to set the time to collect data Defaullt
           to  `10s`
         displayName: Refresh Period
         path: monitoring.metricbeat.refreshPeriod
+      - description: Resources permit to set resources on metricbeat
+        displayName: Resources
+        path: monitoring.metricbeat.resources
       - description: Version is the Metricbeat version to use Default it use the same
           version of the product that it monitor
         displayName: Version
@@ -3349,7 +3361,7 @@ spec:
       - description: AntiAffinity permit to set anti affinity policy
         displayName: Anti Affinity
         path: deployment.antiAffinity
-      - description: TopologyKey is the topology key to use Default to topology.kubernetes.io/zone
+      - description: TopologyKey is the topology key to use Default to kubernetes.io/hostname
         displayName: Topology Key
         path: deployment.antiAffinity.topologyKey
       - description: Type permit to set anti affinity as soft or hard
@@ -3475,13 +3487,17 @@ spec:
           metricbeat to collect metric Default to false
         displayName: Enabled
         path: monitoring.metricbeat.enabled
-      - description: Resources permit to set resources on metricbeat
-        displayName: Resources
-        path: monitoring.metricbeat.initContainerResources
+      - description: NumberOfReplica is the number of replica to set on metricbeat
+          setting when it create templates Default is set to 0
+        displayName: Number Of Replica
+        path: monitoring.metricbeat.numberOfReplicas
       - description: RefreshPeriod permit to set the time to collect data Defaullt
           to  `10s`
         displayName: Refresh Period
         path: monitoring.metricbeat.refreshPeriod
+      - description: Resources permit to set resources on metricbeat
+        displayName: Resources
+        path: monitoring.metricbeat.resources
       - description: Version is the Metricbeat version to use Default it use the same
           version of the product that it monitor
         displayName: Version
@@ -3619,7 +3635,7 @@ spec:
       - description: AntiAffinity permit to set anti affinity policy
         displayName: Anti Affinity
         path: deployment.antiAffinity
-      - description: TopologyKey is the topology key to use Default to topology.kubernetes.io/zone
+      - description: TopologyKey is the topology key to use Default to kubernetes.io/hostname
         displayName: Topology Key
         path: deployment.antiAffinity.topologyKey
       - description: Type permit to set anti affinity as soft or hard
@@ -3787,7 +3803,7 @@ spec:
       - description: Indices is the list of indices permissions
         displayName: Indices
         path: indices
-      - description: Allow to manage restricted index
+      - description: Allow to manage restricted index Default to false
         displayName: Allow Restricted Indices
         path: indices[0].allowRestrictedIndices
       - description: FieldSecurity JSON string
@@ -3847,7 +3863,7 @@ spec:
         path: elasticsearch.indices[0].query
       - description: RunAs is the privilege like users
         displayName: Run As
-        path: elasticsearch.run_as
+        path: elasticsearch.runAs
       - description: Kibana is the Kibana right
         displayName: Kibana
         path: kibana
@@ -3885,7 +3901,10 @@ spec:
         path: name
       - description: TransientMedata
         displayName: Transient Medata
-        path: transient_metadata
+        path: transientMetadata
+      - description: Enabled permit to enable transient metadata
+        displayName: Enabled
+        path: transientMetadata.enabled
       version: v1
     - description: SnapshotLifecyclePolicy is the Schema for the snapshotlifecyclepolicies
         API
@@ -4116,15 +4135,15 @@ spec:
           Default to false
         displayName: Create New Copies
         path: userSpaceCopies[0].createNewCopies
-      - description: CreateNewCopies is set to true to create new copy of objects
-          Default to false
+      - description: ForceUpdateWhenReconcile is set to true to force to sync objects
+          each time the operator reconcile Default to false
         displayName: Force Update When Reconcile
         path: userSpaceCopies[0].forceUpdate
       - description: IncludeReferences is set to true to copy all references Default
           to true
         displayName: Include References
         path: userSpaceCopies[0].includeReferences
-      - description: OriginUserSpace is the user space name from copy objects
+      - description: KibanaObjects is the list of object to copy
         displayName: Kibana Objects
         path: userSpaceCopies[0].objects
       - description: ID is the object to copy
@@ -4229,5 +4248,5 @@ spec:
   provider:
     name: webcenter.fr
     url: https://github.com/webcenter-fr/elasticsearch-operator
-  replaces: elasticsearch-operator.v0.0.37
-  version: 0.0.38
+  replaces: elasticsearch-operator.v0.0.38
+  version: 0.0.39

--- a/controllers/elasticsearch/metricbeat_builder.go
+++ b/controllers/elasticsearch/metricbeat_builder.go
@@ -78,6 +78,9 @@ func buildMetricbeats(es *elasticsearchcrd.Elasticsearch) (mbs []beatcrd.Metricb
 			Module: map[string]string{
 				"elasticsearch-xpack.yml": sb.String(),
 			},
+			Config: map[string]string{
+				"metricbeat.yml": fmt.Sprintf("setup.template.settings:\n  index.number_of_replicas: %d", es.Spec.Monitoring.Metricbeat.NumberOfReplica),
+			},
 			Deployment: beatcrd.MetricbeatDeploymentSpec{
 				Replicas: 1,
 				Env: []corev1.EnvVar{

--- a/controllers/elasticsearch/metricbeat_builder_test.go
+++ b/controllers/elasticsearch/metricbeat_builder_test.go
@@ -119,6 +119,7 @@ func TestBuildMetricbeat(t *testing.T) {
 							corev1.ResourceMemory: resource.MustParse("300Mi"),
 						},
 					},
+					NumberOfReplica: 1,
 				},
 			},
 			NodeGroups: []elasticsearchcrd.ElasticsearchNodeGroupSpec{

--- a/controllers/elasticsearch/testdata/metricbeat_all_set.yaml
+++ b/controllers/elasticsearch/testdata/metricbeat_all_set.yaml
@@ -22,6 +22,10 @@ spec:
         scope: cluster
         period: 5s
         hosts: https://test-es.default.svc:9200
+  config:
+    'metricbeat.yml': |-
+      setup.template.settings:
+        index.number_of_replicas: 1
   deployment:
     replicas: 1
     env:

--- a/controllers/elasticsearch/testdata/metricbeat_default.yaml
+++ b/controllers/elasticsearch/testdata/metricbeat_default.yaml
@@ -21,6 +21,10 @@ spec:
         scope: cluster
         period: 10s
         hosts: https://test-es.default.svc:9200
+  config:
+    'metricbeat.yml': |-
+      setup.template.settings:
+        index.number_of_replicas: 0
   deployment:
     replicas: 1
     env:

--- a/controllers/elasticsearch/testdata/metricbeat_tls_disabled.yaml
+++ b/controllers/elasticsearch/testdata/metricbeat_tls_disabled.yaml
@@ -19,6 +19,10 @@ spec:
         scope: cluster
         period: 10s
         hosts: http://test-es.default.svc:9200
+  config:
+    'metricbeat.yml': |-
+      setup.template.settings:
+        index.number_of_replicas: 0
   deployment:
     replicas: 1
     env:

--- a/controllers/filebeat/metricbeat_builder.go
+++ b/controllers/filebeat/metricbeat_builder.go
@@ -54,6 +54,9 @@ func buildMetricbeats(fb *beatcrd.Filebeat) (metricbeats []beatcrd.Metricbeat, e
 			Module: map[string]string{
 				"beat-xpack.yml": sb.String(),
 			},
+			Config: map[string]string{
+				"metricbeat.yml": fmt.Sprintf("setup.template.settings:\n  index.number_of_replicas: %d", fb.Spec.Monitoring.Metricbeat.NumberOfReplica),
+			},
 			Deployment: beatcrd.MetricbeatDeploymentSpec{
 				Replicas: 1,
 				Env: []corev1.EnvVar{

--- a/controllers/filebeat/metricbeat_builder_test.go
+++ b/controllers/filebeat/metricbeat_builder_test.go
@@ -114,6 +114,7 @@ func TestBuildMetricbeat(t *testing.T) {
 							corev1.ResourceMemory: resource.MustParse("300Mi"),
 						},
 					},
+					NumberOfReplica: 1,
 				},
 			},
 			Deployment: beatcrd.FilebeatDeploymentSpec{

--- a/controllers/filebeat/testdata/metricbeat_all_set.yaml
+++ b/controllers/filebeat/testdata/metricbeat_all_set.yaml
@@ -18,6 +18,10 @@ spec:
           - state
         period: 5s
         hosts: [http://test-fb-0.test-headless-fb.default.svc:5066, http://test-fb-1.test-headless-fb.default.svc:5066, http://test-fb-2.test-headless-fb.default.svc:5066]
+  config:
+    'metricbeat.yml': |-
+      setup.template.settings:
+        index.number_of_replicas: 1
   deployment:
     replicas: 1
     env:

--- a/controllers/filebeat/testdata/metricbeat_default.yaml
+++ b/controllers/filebeat/testdata/metricbeat_default.yaml
@@ -17,6 +17,10 @@ spec:
           - state
         period: 10s
         hosts: [http://test-fb-0.test-headless-fb.default.svc:5066]
+  config:
+    'metricbeat.yml': |-
+      setup.template.settings:
+        index.number_of_replicas: 0
   deployment:
     replicas: 1
     env:

--- a/controllers/kibana/metricbeat_builder.go
+++ b/controllers/kibana/metricbeat_builder.go
@@ -80,6 +80,9 @@ func buildMetricbeats(kb *kibanacrd.Kibana) (mbs []beatcrd.Metricbeat, err error
 			Module: map[string]string{
 				"kibana-xpack.yml": sb.String(),
 			},
+			Config: map[string]string{
+				"metricbeat.yml": fmt.Sprintf("setup.template.settings:\n  index.number_of_replicas: %d", kb.Spec.Monitoring.Metricbeat.NumberOfReplica),
+			},
 			Deployment: beatcrd.MetricbeatDeploymentSpec{
 				Replicas: 1,
 				Env: []corev1.EnvVar{

--- a/controllers/kibana/metricbeat_builder_test.go
+++ b/controllers/kibana/metricbeat_builder_test.go
@@ -116,6 +116,7 @@ func TestBuildMetricbeat(t *testing.T) {
 							corev1.ResourceMemory: resource.MustParse("300Mi"),
 						},
 					},
+					NumberOfReplica: 1,
 				},
 			},
 			Deployment: kibanacrd.KibanaDeploymentSpec{

--- a/controllers/kibana/testdata/metricbeat_all_set.yaml
+++ b/controllers/kibana/testdata/metricbeat_all_set.yaml
@@ -23,6 +23,10 @@ spec:
           - stats
         period: 5s
         hosts: https://test-kb.default.svc:5601
+  config:
+    'metricbeat.yml': |-
+      setup.template.settings:
+        index.number_of_replicas: 1
   deployment:
     replicas: 1
     env:

--- a/controllers/kibana/testdata/metricbeat_default.yaml
+++ b/controllers/kibana/testdata/metricbeat_default.yaml
@@ -22,6 +22,10 @@ spec:
           - stats
         period: 10s
         hosts: https://test-kb.default.svc:5601
+  config:
+    'metricbeat.yml': |-
+      setup.template.settings:
+        index.number_of_replicas: 0
   deployment:
     replicas: 1
     env:

--- a/controllers/kibana/testdata/metricbeat_tls_disabled.yaml
+++ b/controllers/kibana/testdata/metricbeat_tls_disabled.yaml
@@ -20,6 +20,10 @@ spec:
           - stats
         period: 10s
         hosts: http://test-kb.default.svc:5601
+  config:
+    'metricbeat.yml': |-
+      setup.template.settings:
+        index.number_of_replicas: 0
   deployment:
     replicas: 1
     env:

--- a/controllers/logstash/metricbeat_builder.go
+++ b/controllers/logstash/metricbeat_builder.go
@@ -56,6 +56,9 @@ func buildMetricbeats(ls *logstashcrd.Logstash) (metricbeats []beatcrd.Metricbea
 			Module: map[string]string{
 				"logstash-xpack.yml": sb.String(),
 			},
+			Config: map[string]string{
+				"metricbeat.yml": fmt.Sprintf("setup.template.settings:\n  index.number_of_replicas: %d", ls.Spec.Monitoring.Metricbeat.NumberOfReplica),
+			},
 			Deployment: beatcrd.MetricbeatDeploymentSpec{
 				Replicas: 1,
 				Env: []corev1.EnvVar{

--- a/controllers/logstash/metricbeat_builder_test.go
+++ b/controllers/logstash/metricbeat_builder_test.go
@@ -115,6 +115,7 @@ func TestBuildMetricbeat(t *testing.T) {
 							corev1.ResourceMemory: resource.MustParse("300Mi"),
 						},
 					},
+					NumberOfReplica: 1,
 				},
 			},
 			Deployment: logstashcrd.LogstashDeploymentSpec{

--- a/controllers/logstash/testdata/metricbeat_all_set.yaml
+++ b/controllers/logstash/testdata/metricbeat_all_set.yaml
@@ -20,6 +20,10 @@ spec:
           - node_stats
         period: 5s
         hosts: [http://test-ls-0.test-headless-ls.default.svc:9600, http://test-ls-1.test-headless-ls.default.svc:9600, http://test-ls-2.test-headless-ls.default.svc:9600]
+  config:
+    'metricbeat.yml': |-
+      setup.template.settings:
+        index.number_of_replicas: 1
   deployment:
     replicas: 1
     env:

--- a/controllers/logstash/testdata/metricbeat_default.yaml
+++ b/controllers/logstash/testdata/metricbeat_default.yaml
@@ -19,6 +19,10 @@ spec:
           - node_stats
         period: 10s
         hosts: [http://test-ls-0.test-headless-ls.default.svc:9600]
+  config:
+    'metricbeat.yml': |-
+      setup.template.settings:
+        index.number_of_replicas: 0
   deployment:
     replicas: 1
     env:


### PR DESCRIPTION
Set number of replica on metricbeat dedicated to monitor the stack. Default to `0` because of monitoring cluster have only one node in normal case.